### PR TITLE
Add connected inbox limits to pricing page

### DIFF
--- a/pricing.mdx
+++ b/pricing.mdx
@@ -13,12 +13,12 @@ Lindy runs your inbox, meetings, calendar, and follow-ups. Pick the plan that fi
 
 ## Plans at a Glance
 
-| Plan | Price | Usage | Best for |
-|------|-------|-------|----------|
-| **Plus** | $49.99/mo | Standard | Professionals getting started |
-| **Pro** | $99.99/mo | 3x Plus | Heavy use |
-| **Max** | $199.99/mo | 7x Plus | Very heavy use |
-| **Enterprise** | Contact us | Custom | Teams with compliance needs |
+| Plan | Price | Usage | Connected inboxes | Best for |
+|------|-------|-------|-------------------|----------|
+| **Plus** | $49.99/mo | Standard | 2 | Professionals getting started |
+| **Pro** | $99.99/mo | 3x Plus | 3 | Heavy use |
+| **Max** | $199.99/mo | 7x Plus | 5 | Very heavy use |
+| **Enterprise** | Contact us | Custom | Custom | Teams with compliance needs |
 
 ## Plan Details
 
@@ -27,6 +27,7 @@ Lindy runs your inbox, meetings, calendar, and follow-ups. Pick the plan that fi
     **Standard usage** for professionals who want Lindy running their work life.
 
     **What's included:**
+    - **2 connected inboxes**: Connect up to 2 email accounts
     - **iMessage & SMS**: Text Lindy like a friend, 24/7
     - **Inbox management**: Lindy triages, labels, and prioritizes your email automatically
     - **Drafts in your voice**: Replies that sound like you wrote them
@@ -42,6 +43,7 @@ Lindy runs your inbox, meetings, calendar, and follow-ups. Pick the plan that fi
     **3x the usage of Plus** for professionals who delegate to Lindy throughout the day.
 
     **Everything in Plus, plus:**
+    - **3 connected inboxes**: Connect up to 3 email accounts
     - 3x the usage capacity for heavier workloads
     - **Computer use**: Lindy can operate web apps on your behalf
     - Ideal for managing a busy inbox, back-to-back meetings, and frequent ad hoc tasks
@@ -53,6 +55,7 @@ Lindy runs your inbox, meetings, calendar, and follow-ups. Pick the plan that fi
     **7x the usage of Plus** for professionals who run their entire work life through Lindy.
 
     **Everything in Pro, plus:**
+    - **5 connected inboxes**: Connect up to 5 email accounts
     - 7x the usage capacity for the heaviest workloads
     - Built for all-day delegation across inbox, meetings, research, and more
 


### PR DESCRIPTION
## Summary
- Adds connected inbox counts per plan to the pricing page (Plus: 2, Pro: 3, Max: 5, Enterprise: Custom)
- Updated both the "Plans at a Glance" comparison table and each plan's tab in "Plan Details"

## Context
Per Ryan's request in [Slack](https://lindyai.slack.com/archives/C09J4UJBHPY/p1776227656485129):
> Can you update pricing page doc to include the # of connected inboxes for each plan?
> - Plus: 2 inboxes
> - Pro: 3 inboxes
> - Max: 5 inboxes

## Test plan
- [ ] Preview locally with `mintlify dev` and verify the new column renders correctly
- [ ] Verify each plan tab shows the correct inbox count bullet
- [ ] Confirm table formatting is intact on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)