### PR TITLE
Update iMessage default setting label to "auto"

### DIFF
--- a/features/imessage-sms.mdx
+++ b/features/imessage-sms.mdx
@@ -84,7 +84,7 @@ If you're not receiving text messages, ensure your **Preferred Messaging Service
   <img src="/lindy-brand-assets/preferred-messaging.png" alt="Preferred Messaging Service setting on iPhone" />
 </Frame>
 
-The setting defaults to **Default**, but you can override it to match your mobile device. If you're on Android and want to use RCS, open the **Google Messages** app, tap your profile picture, go to **Settings → RCS chats**, and turn on **"Turn on RCS chats"**.
+The setting defaults to **auto**, but you can override it to match your mobile device. If you're on Android and want to use RCS, open the **Google Messages** app, tap your profile picture, go to **Settings → RCS chats**, and turn on **"Turn on RCS chats"**.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- Updates the preferred messaging setting description in `features/imessage-sms.mdx` to say "defaults to **auto**" instead of "defaults to **Default**"

## Test plan
- [ ] Verify wording renders correctly on the iMessage & SMS page

🤖 Generated with [Claude Code](https://claude.com/claude-code)