### PR TITLE
Clarify how to reach account settings on iMessage page

### DIFF
--- a/features/imessage-sms.mdx
+++ b/features/imessage-sms.mdx
@@ -18,7 +18,7 @@ Lindy works over both **iMessage** and **SMS**, so you can delegate to your AI a
 Add your phone number during [signup](/start-here/quickstart) and verify with a confirmation code. That's it. Lindy sends you your first message, already personalized with context from your email and calendar. Just text back.
 
 <Tip>
-If you skipped the phone number step during signup, you can add it anytime in your [account settings](https://chat.lindy.ai).
+If you skipped the phone number step during signup, you can add it anytime: click your workspace image at the top left, then select **Settings** from the dropdown.
 </Tip>
 
 ## What You Can Delegate


### PR DESCRIPTION
## Summary
- Replaces the broken "account settings" link with concise navigation instructions: click workspace image at top left, then select **Settings** from the dropdown

## Test plan
- [ ] Verify the tip renders correctly on the iMessage & SMS page

🤖 Generated with [Claude Code](https://claude.com/claude-code)