### PR TITLE
Mention General settings page for phone number setup

### DIFF
--- a/features/imessage-sms.mdx
+++ b/features/imessage-sms.mdx
@@ -18,7 +18,7 @@ Lindy works over both **iMessage** and **SMS**, so you can delegate to your AI a
 Add your phone number during [signup](/start-here/quickstart) and verify with a confirmation code. That's it. Lindy sends you your first message, already personalized with context from your email and calendar. Just text back.
 
 <Tip>
-If you skipped the phone number step during signup, you can add it anytime: click your workspace image at the top left, then select **Settings** from the dropdown.
+If you skipped the phone number step during signup, you can add it anytime: click your workspace image at the top left, select **Settings** from the dropdown, and find it on the **General** settings page.
 </Tip>
 
 ## What You Can Delegate


### PR DESCRIPTION
## Summary
- Adds clarification that the phone number field is found on the **General** settings page

## Test plan
- [ ] Verify the tip renders correctly on the iMessage & SMS page

🤖 Generated with [Claude Code](https://claude.com/claude-code)