### PR TITLE
Center pin video on best practices page

### DIFF
--- a/start-here/best-practices.mdx
+++ b/start-here/best-practices.mdx
@@ -10,7 +10,7 @@ keywords: ['best practices', 'onboarding', 'setup', 'getting started', 'tips', '
 
 - **Pin Lindy in iMessage** so she's always one tap away
 
-<div style={{ width: '200px', borderRadius: '16px', overflow: 'hidden' }}>
+<div style={{ width: '200px', borderRadius: '16px', overflow: 'hidden', margin: '0 auto' }}>
   <video src="/lindy-brand-assets/pin_video.mov" autoPlay muted loop playsInline style={{ display: 'block', width: '100%' }} />
 </div>
 - **Start with a voice note:** brain-dump for 5 minutes like you're briefing a new hire


### PR DESCRIPTION
## Summary
- Adds `margin: '0 auto'` to the video wrapper div to center it on the page

## Test plan
- [ ] Verify video is centered on the best practices page

🤖 Generated with [Claude Code](https://claude.com/claude-code)