### PR TITLE
Add Meeting Recording, Library & Chat page

### DIFF
--- a/features/meeting-assistant/recording-library.mdx
+++ b/features/meeting-assistant/recording-library.mdx
@@ -1,0 +1,113 @@
+---
+title: 'Meeting Recording, Library & Chat'
+icon: 'video'
+sidebarTitle: 'Recording, Library & Chat'
+description: 'Lindy automatically joins, records, and transcribes your meetings, saves them to a searchable library, and lets you query any past meeting in plain language'
+keywords: ['meeting recording', 'meeting library', 'chat with meetings', 'transcript', 'notetaker', 'meeting summary', 'meeting notes', 'search meetings', 'daily brief', 'meeting prep', 'follow-up']
+---
+
+Lindy automatically joins your meetings, records them, transcribes every word, and delivers structured notes, no manual effort required. Every recording is saved to a searchable library, and you can query any past meeting in plain language, just like a conversation.
+
+## 1. Meeting Scheduling
+
+Lindy can coordinate meetings and propose times on your behalf by email. From **Meetings → Settings**, you can configure:
+
+- **Meeting limits**: cap the total hours Lindy can schedule within a given period
+- **Meeting provider**: set your default conferencing tool
+- **Default duration**: set the default meeting length in minutes
+- **Earliest / Latest meeting time**: define your available scheduling window
+- **Allowed days of the week**: choose which days Lindy can book
+- **Custom rules**: add plain-language scheduling instructions for edge cases
+
+## 2. Meeting Prep
+
+Get summaries, agendas, and context automatically before every meeting. Configure in **Meetings → Settings**:
+
+- **Send prep emails for**: choose which meetings trigger a prep email
+- **Prep Instructions**: define structure, tone, level of detail, and what sources to pull from (including third-party tools)
+- **Timing**: choose how many minutes before each meeting to receive your prep
+- **Notify via**: Email or SMS / iMessage
+
+## 3. Meeting Recording
+
+Enable Lindy to join and record your meetings from **Meetings → Settings → Meeting recording**.
+
+**Supported platforms:**
+
+- Google Meet
+- Zoom
+
+Once enabled, configure:
+
+- **Join meetings**: toggle to allow Lindy to attend scheduled meetings automatically
+- **Notetaker display name**: set the name Lindy uses when it joins (e.g. "Sarah's Notetaker")
+- **Send follow-up email to**: choose who receives the post-meeting summary
+- **Summarization instructions**: define the format, tone, and detail level for your summaries
+- **Notify via**: Email or SMS / iMessage
+
+After every meeting, Lindy delivers:
+
+| Section | What You Get |
+|---|---|
+| **High-level summary** | Top-line outcomes and key decisions |
+| **Detailed notes** | In-depth bullet points from the full discussion |
+| **Action items** | Who needs to do what, with clear ownership |
+| **Full transcript** | Searchable, timestamped transcript |
+| **Recording link** | Direct link to replay the session |
+
+You can edit **Summarization Instructions** to control the format on every future meeting.
+
+## 4. Follow-up Actions
+
+Define what Lindy can do automatically after meetings. This is a free-form rules section where you set conditions and actions, for example, updating a CRM after a sales call, sending notes to a specific person, or triggering a follow-up task based on meeting content.
+
+## 5. Daily Briefs
+
+Lindy delivers a daily brief summarising what matters. Configure in **Meetings → Settings → Daily briefs**:
+
+- **Information to include**: define what Lindy should surface (meetings, emails, news, etc.)
+- **Timing**: choose what time each day to receive your brief (defaults to 7:00 AM)
+
+## 6. Meeting Library
+
+Every recorded meeting is saved to your Lindy dashboard automatically.
+
+From the dashboard you can:
+
+- Click any meeting to open the recording and transcript
+- Copy the transcript using the **Copy** icon
+- Download the recording via the **three dots menu**
+- Delete individual meetings or your full history at any time
+- Search across all meetings by keyword, person, or topic
+
+## 7. Chat with Your Meetings
+
+Your meeting library becomes a knowledge base you can query in plain language, via Lindy Assistant (iMessage, SMS, or RCS) or directly in the dashboard.
+
+Example queries:
+
+- "What did we decide in last week's meeting with Sarah?"
+- "What were the action items from Tuesday's standup?"
+- "What did [name] say about pricing in our last call?"
+- "What did I commit to sending [name]?"
+
+Lindy pulls relevant notes from your history instantly. The more meetings you record, the richer the context Lindy can draw on for answering questions and preparing you for upcoming calls.
+
+## Quick Setup
+
+1. Go to [chat.lindy.ai](https://chat.lindy.ai) → **Meetings → Settings**
+2. Toggle on **Meeting recording**
+3. Connect your Google Calendar or Microsoft Outlook calendar
+4. Set your notetaker display name and summarization instructions
+5. Lindy joins and records from your next scheduled meeting
+
+## Relevant Docs
+
+<CardGroup cols={2}>
+  <Card title="Meeting Notes" icon="microphone" href="/features/meeting-assistant/meeting-notes">
+    Structured summaries, transcripts, and recordings
+  </Card>
+  <Card title="Meeting Prep" icon="clipboard-list" href="/features/meeting-assistant/meeting-prep">
+    Automated briefings before every meeting
+  </Card>
+</CardGroup>

--- a/mint.json
+++ b/mint.json
@@ -65,7 +65,8 @@
         "features/meeting-assistant/meeting-prep",
         "features/meeting-assistant/meeting-notes",
         "features/meeting-assistant/follow-ups",
-        "features/meeting-assistant/scheduling"
+        "features/meeting-assistant/scheduling",
+        "features/meeting-assistant/recording-library"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Adds new page `features/meeting-assistant/recording-library.mdx` covering all meeting assistant settings and features in one place
- Registers the page in `mint.json` under the Meeting Assistant nav group
- Content covers: Scheduling, Prep, Recording, Follow-up Actions, Daily Briefs, Meeting Library, and Chat with Your Meetings

🤖 Generated with [Claude Code](https://claude.com/claude-code)