### PR TITLE
Remove duplicate intro on recording-library page

### DIFF
--- a/features/meeting-assistant/recording-library.mdx
+++ b/features/meeting-assistant/recording-library.mdx
@@ -6,8 +6,6 @@ description: 'Lindy automatically joins, records, and transcribes your meetings,
 keywords: ['meeting recording', 'meeting library', 'chat with meetings', 'transcript', 'notetaker', 'meeting summary', 'meeting notes', 'search meetings', 'daily brief', 'meeting prep', 'follow-up']
 ---
 
-Lindy automatically joins your meetings, records them, transcribes every word, and delivers structured notes, no manual effort required. Every recording is saved to a searchable library, and you can query any past meeting in plain language, just like a conversation.
-
 ## 1. Meeting Scheduling
 
 Lindy can coordinate meetings and propose times on your behalf by email. From **Meetings → Settings**, you can configure:


### PR DESCRIPTION
Removes the body paragraph that duplicates the frontmatter description, which already renders in small font below the page title.