### PR TITLE
Wrap example queries in AccordionGroup

### DIFF
--- a/features/meeting-assistant/recording-library.mdx
+++ b/features/meeting-assistant/recording-library.mdx
@@ -82,12 +82,20 @@ From the dashboard you can:
 
 Your meeting library becomes a knowledge base you can query in plain language, via Lindy Assistant (iMessage, SMS, or RCS) or directly in the dashboard.
 
-Example queries:
-
-- "What did we decide in last week's meeting with Sarah?"
-- "What were the action items from Tuesday's standup?"
-- "What did [name] say about pricing in our last call?"
-- "What did I commit to sending [name]?"
+<AccordionGroup>
+  <Accordion title="What did we decide in last week's meeting with Sarah?">
+    Lindy searches your meeting library and surfaces the key decisions from that call.
+  </Accordion>
+  <Accordion title="What were the action items from Tuesday's standup?">
+    Lindy pulls the action items section from the relevant meeting summary.
+  </Accordion>
+  <Accordion title="What did [name] say about pricing in our last call?">
+    Lindy finds and quotes the relevant part of the transcript from your most recent call with that person.
+  </Accordion>
+  <Accordion title="What did I commit to sending [name]?">
+    Lindy checks your meeting notes and action items to find any commitments you made.
+  </Accordion>
+</AccordionGroup>
 
 Lindy pulls relevant notes from your history instantly. The more meetings you record, the richer the context Lindy can draw on for answering questions and preparing you for upcoming calls.
 


### PR DESCRIPTION
Replaces the plain bullet list of example queries with an AccordionGroup so each query expands to show context on what Lindy does.