### PR TITLE
Condense scheduling & prep sections on recording-library page

### DIFF
--- a/features/meeting-assistant/recording-library.mdx
+++ b/features/meeting-assistant/recording-library.mdx
@@ -8,23 +8,11 @@ keywords: ['meeting recording', 'meeting library', 'chat with meetings', 'transc
 
 ## 1. Meeting Scheduling
 
-Lindy can coordinate meetings and propose times on your behalf by email. From **Meetings → Settings**, you can configure:
-
-- **Meeting limits**: cap the total hours Lindy can schedule within a given period
-- **Meeting provider**: set your default conferencing tool
-- **Default duration**: set the default meeting length in minutes
-- **Earliest / Latest meeting time**: define your available scheduling window
-- **Allowed days of the week**: choose which days Lindy can book
-- **Custom rules**: add plain-language scheduling instructions for edge cases
+Lindy proposes times and coordinates meetings on your behalf by email. Configure limits, duration, availability, and custom rules in **Meetings → Settings**. [Full details →](/features/meeting-assistant/scheduling)
 
 ## 2. Meeting Prep
 
-Get summaries, agendas, and context automatically before every meeting. Configure in **Meetings → Settings**:
-
-- **Send prep emails for**: choose which meetings trigger a prep email
-- **Prep Instructions**: define structure, tone, level of detail, and what sources to pull from (including third-party tools)
-- **Timing**: choose how many minutes before each meeting to receive your prep
-- **Notify via**: Email or SMS / iMessage
+Lindy sends you a structured briefing before every meeting — summaries, agendas, and context from your tools. Configure timing, format, and sources in **Meetings → Settings**. [Full details →](/features/meeting-assistant/meeting-prep)
 
 ## 3. Meeting Recording
 
@@ -57,14 +45,14 @@ You can edit **Summarization Instructions** to control the format on every futur
 
 ## 4. Follow-up Actions
 
-Define what Lindy can do automatically after meetings. This is a free-form rules section where you set conditions and actions, for example, updating a CRM after a sales call, sending notes to a specific person, or triggering a follow-up task based on meeting content.
+Set conditions and actions Lindy runs automatically after meetings — updating a CRM, sending notes to someone, or triggering tasks based on meeting content. Configured as free-form rules in **Meetings → Settings**.
 
 ## 5. Daily Briefs
 
 Lindy delivers a daily brief summarising what matters. Configure in **Meetings → Settings → Daily briefs**:
 
-- **Information to include**: define what Lindy should surface (meetings, emails, news, etc.)
-- **Timing**: choose what time each day to receive your brief (defaults to 7:00 AM)
+- **Information to include**: what Lindy should surface (meetings, emails, news, etc.)
+- **Timing**: what time to receive your brief (defaults to 7:00 AM)
 
 ## 6. Meeting Library
 


### PR DESCRIPTION
## Summary
- Condenses §1 Scheduling and §2 Prep to single-line summaries with links to their dedicated pages
- Trims §4 Follow-up Actions and §5 Daily Briefs slightly
- All core content (§3 Recording, §6 Library, §7 Chat) kept in full

🤖 Generated with [Claude Code](https://claude.com/claude-code)