### PR TITLE
Remove arrows from Full details links

### DIFF
--- a/features/meeting-assistant/recording-library.mdx
+++ b/features/meeting-assistant/recording-library.mdx
@@ -8,11 +8,11 @@ keywords: ['meeting recording', 'meeting library', 'chat with meetings', 'transc
 
 ## 1. Meeting Scheduling
 
-Lindy proposes times and coordinates meetings on your behalf by email. Configure limits, duration, availability, and custom rules in **Meetings → Settings**. [Full details →](/features/meeting-assistant/scheduling)
+Lindy proposes times and coordinates meetings on your behalf by email. Configure limits, duration, availability, and custom rules in **Meetings → Settings**. [Full details](/features/meeting-assistant/scheduling)
 
 ## 2. Meeting Prep
 
-Lindy sends you a structured briefing before every meeting — summaries, agendas, and context from your tools. Configure timing, format, and sources in **Meetings → Settings**. [Full details →](/features/meeting-assistant/meeting-prep)
+Lindy sends you a structured briefing before every meeting — summaries, agendas, and context from your tools. Configure timing, format, and sources in **Meetings → Settings**. [Full details](/features/meeting-assistant/meeting-prep)
 
 ## 3. Meeting Recording
 


### PR DESCRIPTION
Cleans up the 'Full details →' links in §1 and §2 by removing the arrow.