### PR TITLE
Add enable meetings image to recording section

### DIFF
--- a/features/meeting-assistant/recording-library.mdx
+++ b/features/meeting-assistant/recording-library.mdx
@@ -18,6 +18,10 @@ Lindy sends you a structured briefing before every meeting — summaries, agenda
 
 Enable Lindy to join and record your meetings from **Meetings → Settings → Meeting recording**.
 
+<Frame>
+  <img src="/lindy-brand-assets/enable%20meetings.png" alt="Enable meeting recording in Lindy settings" />
+</Frame>
+
 **Supported platforms:**
 
 - Google Meet


### PR DESCRIPTION
Adds the enable meetings screenshot directly under the Meeting recording settings intro line in §3.