### PR TITLE
Link Summarization Instructions to meeting-notes anchor

### DIFF
--- a/features/meeting-assistant/recording-library.mdx
+++ b/features/meeting-assistant/recording-library.mdx
@@ -45,7 +45,7 @@ After every meeting, Lindy delivers:
 | **Full transcript** | Searchable, timestamped transcript |
 | **Recording link** | Direct link to replay the session |
 
-You can edit **Summarization Instructions** to control the format on every future meeting.
+You can edit [**Summarization Instructions**](/features/meeting-assistant/meeting-notes#summary-structure) to control the format on every future meeting.
 
 ## 4. Follow-up Actions
 


### PR DESCRIPTION
Makes 'Summarization Instructions' in §3 a link to /features/meeting-assistant/meeting-notes#summary-structure.