### PR TITLE
Tighten Recording, Library & Chat page

### DIFF
--- a/features/meeting-assistant/recording-library.mdx
+++ b/features/meeting-assistant/recording-library.mdx
@@ -6,36 +6,17 @@ description: 'Lindy automatically joins, records, and transcribes your meetings,
 keywords: ['meeting recording', 'meeting library', 'chat with meetings', 'transcript', 'notetaker', 'meeting summary', 'meeting notes', 'search meetings', 'daily brief', 'meeting prep', 'follow-up']
 ---
 
-## 1. Meeting Scheduling
+Lindy joins your meetings, records and transcribes them, and saves everything to a searchable library you can query in plain language.
 
-Lindy proposes times and coordinates meetings on your behalf by email. Configure limits, duration, availability, and custom rules in **Meetings → Settings**. [Full details](/features/meeting-assistant/scheduling)
+## Recording
 
-## 2. Meeting Prep
-
-Lindy sends you a structured briefing before every meeting — summaries, agendas, and context from your tools. Configure timing, format, and sources in **Meetings → Settings**. [Full details](/features/meeting-assistant/meeting-prep)
-
-## 3. Meeting Recording
-
-Enable Lindy to join and record your meetings from **Meetings → Settings → Meeting recording**.
+Turn on recording from **Meetings → Settings → Meeting recording**. Supported on Google Meet and Zoom.
 
 <Frame>
   <img src="/lindy-brand-assets/enable%20meetings.png" alt="Enable meeting recording in Lindy settings" />
 </Frame>
 
-**Supported platforms:**
-
-- Google Meet
-- Zoom
-
-Once enabled, configure:
-
-- **Join meetings**: toggle to allow Lindy to attend scheduled meetings automatically
-- **Notetaker display name**: set the name Lindy uses when it joins (e.g. "Sarah's Notetaker")
-- **Send follow-up email to**: choose who receives the post-meeting summary
-- **Summarization instructions**: define the format, tone, and detail level for your summaries
-- **Notify via**: Email or SMS / iMessage
-
-After every meeting, Lindy delivers:
+Set your notetaker display name, who receives the post-meeting summary, and your preferred summarization format. After every meeting, Lindy delivers:
 
 | Section | What You Get |
 |---|---|
@@ -45,20 +26,9 @@ After every meeting, Lindy delivers:
 | **Full transcript** | Searchable, timestamped transcript |
 | **Recording link** | Direct link to replay the session |
 
-You can edit [**Summarization Instructions**](/features/meeting-assistant/meeting-notes#summary-structure) to control the format on every future meeting.
+Edit [Summarization Instructions](/features/meeting-assistant/meeting-notes#summary-structure) to control the format on every future meeting.
 
-## 4. Follow-up Actions
-
-Set conditions and actions Lindy runs automatically after meetings — updating a CRM, sending notes to someone, or triggering tasks based on meeting content. Configured as free-form rules in **Meetings → Settings**.
-
-## 5. Daily Briefs
-
-Lindy delivers a daily brief summarising what matters. Configure in **Meetings → Settings → Daily briefs**:
-
-- **Information to include**: what Lindy should surface (meetings, emails, news, etc.)
-- **Timing**: what time to receive your brief (defaults to 7:00 AM)
-
-## 6. Meeting Library
+## Library
 
 Every recorded meeting is saved to your Lindy dashboard automatically.
 
@@ -66,24 +36,18 @@ Every recorded meeting is saved to your Lindy dashboard automatically.
   <img src="/lindy-brand-assets/Meetings Page arrow.png" alt="Meeting library in Lindy dashboard" width="700" />
 </Frame>
 
-From the dashboard you can:
+Open any meeting to view the recording and transcript, copy or download it, delete individual entries or your full history, and search across all meetings by keyword, person, or topic.
 
-- Click any meeting to open the recording and transcript
-- Copy the transcript using the **Copy** icon
-- Download the recording via the **three dots menu**
-- Delete individual meetings or your full history at any time
-- Search across all meetings by keyword, person, or topic
+## Chat
 
-## 7. Chat with Your Meetings
-
-Your meeting library becomes a knowledge base you can query in plain language, via Lindy Assistant (iMessage, SMS, or RCS) or directly in the dashboard.
+Your meeting library becomes a knowledge base you can query in plain language — via iMessage, SMS, or directly in the dashboard.
 
 - "What did we decide in last week's meeting with Sarah?"
 - "What were the action items from Tuesday's standup?"
 - "What did [name] say about pricing in our last call?"
 - "What did I commit to sending [name]?"
 
-Lindy pulls relevant notes from your history instantly. The more meetings you record, the richer the context Lindy can draw on for answering questions and preparing you for upcoming calls.
+The more meetings you record, the richer the context Lindy can draw on.
 
 ## Quick Setup
 
@@ -101,5 +65,11 @@ Lindy pulls relevant notes from your history instantly. The more meetings you re
   </Card>
   <Card title="Meeting Prep" icon="clipboard-list" href="/features/meeting-assistant/meeting-prep">
     Automated briefings before every meeting
+  </Card>
+  <Card title="Follow-ups" icon="envelope" href="/features/meeting-assistant/follow-ups">
+    Automatic actions after every meeting
+  </Card>
+  <Card title="Smart Scheduling" icon="calendar" href="/features/meeting-assistant/scheduling">
+    Lindy proposes times and books meetings for you
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary

- Removes Scheduling, Meeting Prep, Follow-up Actions, and Daily Briefs sections — each has its own dedicated page and didn't belong here
- Condenses Recording config list (5 bullets → 1 sentence) and Library bullet list into prose
- Adds Follow-ups and Smart Scheduling to the Relevant Docs cards so those topics remain discoverable
- Page goes from 106 → 74 lines and now matches what the title promises

## Test plan

- [ ] Preview locally with `mintlify dev` and check the page renders correctly
- [ ] Verify all links in Relevant Docs cards resolve (meeting-notes, meeting-prep, follow-ups, scheduling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)