### PR TITLE
Add settings note to When You Receive Prep section

### DIFF
--- a/features/meeting-assistant/meeting-prep.mdx
+++ b/features/meeting-assistant/meeting-prep.mdx
@@ -46,6 +46,10 @@ You can customize the prep format in your settings at [chat.lindy.ai](https://ch
 
 ## When You Receive Prep
 
+<Note>
+  To adjust these settings, go to **Meetings** in your Lindy settings, scroll down to **Meeting Prep**, and configure the time.
+</Note>
+
 <div style={{ display: 'flex', justifyContent: 'center', margin: '2rem 0' }}>
   <div className="video-card">
     <video


### PR DESCRIPTION
## Summary
- Added a Note callout above the video in **When You Receive Prep** explaining how to adjust timing settings: Meetings → scroll to Meeting Prep → configure the time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)