### PR TITLE
Move bullets above video and add settings note to How You Receive Prep

### DIFF
--- a/features/meeting-assistant/meeting-prep.mdx
+++ b/features/meeting-assistant/meeting-prep.mdx
@@ -71,6 +71,13 @@ You can enable one or both.
 
 ## How You Receive Prep
 
+- **Email**: lands in your inbox
+- **SMS / iMessage**: sent directly to your phone
+
+<Note>
+  To change how you're notified, go to **Meetings** in your Lindy settings, scroll down to **Meeting Prep**, and update your notification preferences.
+</Note>
+
 <div style={{ display: 'flex', justifyContent: 'center', margin: '2rem 0' }}>
   <div className="video-card">
     <video
@@ -84,9 +91,6 @@ You can enable one or both.
     />
   </div>
 </div>
-
-- **Email**: lands in your inbox
-- **SMS / iMessage**: sent directly to your phone
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- Moved Email and SMS/iMessage bullet points above the video in **How You Receive Prep**
- Added a Note callout explaining how to change notification settings: Meetings → scroll to Meeting Prep → update notification preferences

🤖 Generated with [Claude Code](https://claude.com/claude-code)