### PR TITLE
Increase when/how prep video width from 600 to 800

### DIFF
--- a/features/meeting-assistant/meeting-prep.mdx
+++ b/features/meeting-assistant/meeting-prep.mdx
@@ -54,7 +54,7 @@ You can customize the prep format in your settings at [chat.lindy.ai](https://ch
   <div className="video-card">
     <video
       src="/lindy-brand-assets/when%20prep.mp4"
-      width="600"
+      width="800"
       autoPlay
       muted
       loop
@@ -82,7 +82,7 @@ You can enable one or both.
   <div className="video-card">
     <video
       src="/lindy-brand-assets/how%20prep.mp4"
-      width="600"
+      width="800"
       autoPlay
       muted
       loop


### PR DESCRIPTION
## Summary
- Bumped both "When You Receive Prep" and "How You Receive Prep" video widths from 600px to 800px

🤖 Generated with [Claude Code](https://claude.com/claude-code)