### PR TITLE
Add Daily Brief page under Meeting Assistant

### DIFF
--- a/features/meeting-assistant/daily-brief.mdx
+++ b/features/meeting-assistant/daily-brief.mdx
@@ -1,0 +1,48 @@
+---
+title: 'Daily Brief'
+description: 'A personalized daily briefing on your day, meetings, and anything else you care about'
+icon: 'newspaper'
+keywords: ['daily brief', 'briefing', 'morning summary', 'day overview', 'news']
+---
+
+## Start Every Day Knowing What Matters
+
+<div style={{ display: 'flex', justifyContent: 'center', margin: '2rem 0' }}>
+  <div className="video-card">
+    <video
+      src="/lindy-brand-assets/daily%20brief.mp4"
+      width="800"
+      autoPlay
+      muted
+      loop
+      playsInline
+      style={{ display: 'block', width: '100%', borderRadius: '16px' }}
+    />
+  </div>
+</div>
+
+Lindy can send you a daily brief on anything you prompt it to cover. Tell it exactly what you want — your schedule, who you're meeting, industry news, priorities — and it lands in your inbox every morning before your day starts.
+
+For example:
+
+> *"Brief me about my day, who I'm meeting with, and news regarding my industry."*
+
+Lindy reads your calendar, pulls relevant context, and delivers a clean summary without you having to ask.
+
+## How to Set It Up
+
+To edit your daily brief, go to **Meetings** in your Lindy settings and scroll down to the **Daily Brief** section. From there you can:
+
+- Write a custom prompt to define what Lindy covers
+- Set the time you want it delivered each morning
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Meeting Prep" icon="clipboard-list" href="/features/meeting-assistant/meeting-prep">
+    Automatic briefings before each meeting
+  </Card>
+  <Card title="Meeting Notes" icon="microphone" href="/features/meeting-assistant/meeting-notes">
+    How Lindy records and summarizes your meetings
+  </Card>
+</CardGroup>

--- a/mint.json
+++ b/mint.json
@@ -63,6 +63,7 @@
       "group": "Meeting Assistant",
       "pages": [
         "features/meeting-assistant/meeting-prep",
+        "features/meeting-assistant/daily-brief",
         "features/meeting-assistant/meeting-notes",
         "features/meeting-assistant/follow-ups",
         "features/meeting-assistant/scheduling"


### PR DESCRIPTION
## Summary
- Created new `features/meeting-assistant/daily-brief.mdx` page
- Includes `daily brief.mp4` video, example prompt, and settings instructions (Meetings → Daily Brief)
- Registered in `mint.json` nav between Meeting Prep and Meeting Notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)