### PR TITLE
Remove broken links to deleted popular-workflows pages

### DIFF
--- a/fundamentals/lindy-101/introduction.mdx
+++ b/fundamentals/lindy-101/introduction.mdx
@@ -151,7 +151,7 @@ Ready to create your first custom workflow? Here's how to get started:
 
 <Steps>
   <Step title="Try a template">
-    Browse our [use cases](/use-cases/popular-workflows/meeting-assistant) to see what's possible and get inspired by real-world examples
+    Browse our use cases to see what's possible and get inspired by real-world examples
   </Step>
   <Step title="Build your first workflow">
     Follow our [step-by-step guide](/fundamentals/lindy-101/create-agent) to create your first custom workflow

--- a/fundamentals/lindy-101/templates.mdx
+++ b/fundamentals/lindy-101/templates.mdx
@@ -149,7 +149,4 @@ Before creating a template, consider:
   <Card title="Community" href="https://community.lindy.ai/join" icon="users">
     Share and discover templates with other Lindy users
   </Card>
-  <Card title="Use Cases" href="/use-cases/popular-workflows/meeting-assistant" icon="video">
-    Explore real-world examples and workflows
-  </Card>
 </CardGroup> 

--- a/skills/by-lindy/lindy-mail.mdx
+++ b/skills/by-lindy/lindy-mail.mdx
@@ -139,9 +139,6 @@ This approach ensures your agent provides consistent, high-quality responses tha
   <Card title="Gmail Integration" href="/skills/popular-integrations/gmail" icon="envelope">
     Compare Lindy Mail with Gmail integration options
   </Card>
-  <Card title="Email Assistant" href="/use-cases/popular-workflows/email-triage" icon="envelope">
-    Build advanced email automation workflows
-  </Card>
   <Card title="Triggers" href="/fundamentals/lindy-101/triggers" icon="bolt">
     Set up email-based triggers
   </Card>

--- a/skills/popular-integrations/gmail.mdx
+++ b/skills/popular-integrations/gmail.mdx
@@ -146,9 +146,6 @@ HTML Email Signatures: In the signature field, you can include HTML email signat
 ## Related Resources
 
 <CardGroup cols={2}>
-  <Card title="Email Assistant" href="/use-cases/popular-workflows/email-triage" icon="envelope">
-    Step-by-step email automation guide
-  </Card>
   <Card title="Google Calendar" href="/skills/popular-integrations/google-calendar" icon="calendar-range">
     Combine email and calendar automation
   </Card>

--- a/skills/popular-integrations/google-calendar.mdx
+++ b/skills/popular-integrations/google-calendar.mdx
@@ -266,9 +266,6 @@ Lists events from calendars with optional filtering:
   <Card title="Slack Integration" icon="comments" href="/skills/popular-integrations/slack">
     Connect calendar events to team communication
   </Card>
-  <Card title="Scheduling Assistant" icon="calendar-range" href="/use-cases/popular-workflows/scheduling-assistant">
-    Build intelligent meeting schedulers
-  </Card>
   <Card title="Triggers" icon="bolt" href="/fundamentals/lindy-101/triggers">
     Set up calendar-based triggers
   </Card>


### PR DESCRIPTION
## Summary
- Removes broken links to the 4 deleted `popular-workflows` pages across 5 files:
  - `fundamentals/lindy-101/introduction.mdx` — unlinked the text reference
  - `fundamentals/lindy-101/templates.mdx` — removed card
  - `skills/popular-integrations/google-calendar.mdx` — removed card
  - `skills/popular-integrations/gmail.mdx` — removed card
  - `skills/by-lindy/lindy-mail.mdx` — removed card

## Test plan
- [ ] Verify Mintlify build passes
- [ ] Check no remaining references to `popular-workflows` in nav or content

🤖 Generated with [Claude Code](https://claude.com/claude-code)