### PR TITLE
Move Accounts & Billing to the Documentation tab

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -69,6 +69,15 @@
             ]
           },
           {
+            "group": "Accounts & Billing",
+            "pages": [
+              "account-billing/usage",
+              "account-billing/teams-collaboration",
+              "account-billing/credits",
+              "account-billing/multi-account"
+            ]
+          },
+          {
             "group": "Resources",
             "pages": [
               "resources/security",
@@ -110,15 +119,6 @@
               "testing/debugging",
               "testing/monitoring-your-agents",
               "testing/version-history"
-            ]
-          },
-          {
-            "group": "Accounts & Billing",
-            "pages": [
-              "account-billing/usage",
-              "account-billing/teams-collaboration",
-              "account-billing/credits",
-              "account-billing/multi-account"
             ]
           },
           {


### PR DESCRIPTION
## Summary

Moves the **Accounts & Billing** nav group from the Workflows tab to the Documentation tab (between Meeting Assistant and Resources). It's user-facing content, so it belongs with the core docs rather than buried under Workflows.

## Test plan
- [ ] Accounts & Billing appears under the Documentation tab
- [ ] It no longer shows under the Workflows tab