### PR TITLE
Remove broken Recording Library nav entry

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -64,8 +64,7 @@
               "features/meeting-assistant/meeting-prep",
               "features/meeting-assistant/meeting-notes",
               "features/meeting-assistant/follow-ups",
-              "features/meeting-assistant/scheduling",
-              "features/meeting-assistant/recording-library"
+              "features/meeting-assistant/scheduling"
             ]
           },
           {


### PR DESCRIPTION
## Summary

The Meeting Assistant nav listed `features/meeting-assistant/recording-library`, but that page file is not on `main` (its content was previously folded into the meeting-notes page). The entry 404s on the live site.

Removes the nav entry. The page can be re-added if/when the standalone file is restored.

## Test plan
- [ ] Recording Library no longer appears under Meeting Assistant
- [ ] No 404 from the sidebar