### PR TITLE
Split Accounts & Billing: hide Team Collaboration in Documentation tab

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -71,7 +71,6 @@
             "group": "Accounts & Billing",
             "pages": [
               "account-billing/usage",
-              "account-billing/teams-collaboration",
               "account-billing/credits",
               "account-billing/multi-account"
             ]
@@ -118,6 +117,15 @@
               "testing/debugging",
               "testing/monitoring-your-agents",
               "testing/version-history"
+            ]
+          },
+          {
+            "group": "Accounts & Billing",
+            "pages": [
+              "account-billing/usage",
+              "account-billing/teams-collaboration",
+              "account-billing/credits",
+              "account-billing/multi-account"
             ]
           },
           {


### PR DESCRIPTION
## Summary

Team Collaboration applies to the legacy workflow product, not the new product.

- **Documentation tab** → Accounts & Billing: usage, credits, multi-account (Team Collaboration removed)
- **Workflows tab** → Accounts & Billing: usage, **team-collaboration**, credits, multi-account (full set)

The `teams-collaboration` page still exists and is reachable; it just no longer appears in the Documentation-tab sidebar.

## Test plan
- [ ] Documentation tab: Accounts & Billing has no Team Collaboration entry
- [ ] Workflows tab: Accounts & Billing includes Team Collaboration