### PR TITLE
Remove Credits from Documentation-tab Accounts & Billing

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -71,7 +71,6 @@
             "group": "Accounts & Billing",
             "pages": [
               "account-billing/usage",
-              "account-billing/credits",
               "account-billing/multi-account"
             ]
           },


### PR DESCRIPTION
## Summary

Removes the Credits page from the Documentation-tab Accounts & Billing group. It stays in the Workflows-tab Accounts & Billing group.

- **Documentation** → Accounts & Billing: Usage, Multi-Account
- **Workflows** → Accounts & Billing: Usage, Team Collaboration, Credits, Multi-Account

## Test plan
- [ ] Documentation tab: Accounts & Billing has no Credits entry
- [ ] Workflows tab: Accounts & Billing still includes Credits