### PR TITLE
Add Daily Brief to Meeting Assistant

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -64,7 +64,8 @@
               "features/meeting-assistant/meeting-prep",
               "features/meeting-assistant/meeting-notes",
               "features/meeting-assistant/follow-ups",
-              "features/meeting-assistant/scheduling"
+              "features/meeting-assistant/scheduling",
+              "features/meeting-assistant/daily-brief"
             ]
           },
           {

--- a/features/meeting-assistant/daily-brief.mdx
+++ b/features/meeting-assistant/daily-brief.mdx
@@ -1,0 +1,80 @@
+---
+title: 'Daily Brief'
+description: 'A personalized daily briefing on your day, meetings, and anything else you care about'
+icon: 'newspaper'
+keywords: ['daily brief', 'briefing', 'morning summary', 'day overview', 'news']
+---
+
+## Start Every Day Knowing What Matters
+
+<div style={{ display: 'flex', justifyContent: 'center', margin: '2rem 0' }}>
+  <div className="video-card">
+    <video
+      src="/lindy-brand-assets/daily%20brief.mp4"
+      width="800"
+      autoPlay
+      muted
+      loop
+      playsInline
+      style={{ display: 'block', width: '100%', borderRadius: '16px' }}
+    />
+  </div>
+</div>
+
+Lindy can send you a daily brief on anything you prompt it to cover. Tell it exactly what you want: your schedule, who you're meeting, industry news, priorities. It lands in your inbox every morning before your day starts.
+
+## What You Can Include
+
+Tell Lindy what to cover in your brief. Common topics:
+
+- **Your schedule**: every meeting on your calendar with times and attendees
+- **Meeting context**: who you're meeting and what you've discussed before
+- **Industry news**: headlines and updates relevant to your work
+- **Priorities**: a summary of open tasks, emails, or follow-ups
+- **Weather**: local forecast for the day
+
+For example:
+
+> *"Brief me about my day, who I'm meeting with, and news regarding my industry."*
+
+Lindy reads your calendar, pulls relevant context, and delivers a clean summary without you having to ask.
+
+## What It Looks Like
+
+<Frame>
+  <img src="/lindy-brand-assets/daily-briefing.jpg" alt="Daily brief email showing schedule, meeting attendees, and industry news" />
+</Frame>
+
+## How You Receive It
+
+- **Email**: lands in your inbox each morning
+- **SMS / iMessage**: sent directly to your phone
+
+## How to Set It Up
+
+<Note>
+  Go to **Meetings** in your Lindy settings and scroll down to **Daily Brief** to configure your brief.
+</Note>
+
+<Steps>
+  <Step title="Write your prompt">
+    Describe what you want Lindy to cover each morning. Be as specific as you like — topics, format, level of detail.
+  </Step>
+  <Step title="Set your delivery time">
+    Choose when the brief arrives. Most people set it 30–60 minutes before their workday starts.
+  </Step>
+  <Step title="Choose your delivery method">
+    Select email, SMS / iMessage, or both.
+  </Step>
+</Steps>
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Meeting Prep" icon="clipboard-list" href="/features/meeting-assistant/meeting-prep">
+    Automatic briefings before each meeting
+  </Card>
+  <Card title="Meeting Notes" icon="microphone" href="/features/meeting-assistant/meeting-notes">
+    How Lindy records and summarizes your meetings
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

- Adds `features/meeting-assistant/daily-brief.mdx` (ported from `pivot`)
- Registers it under **Meeting Assistant** in `docs.json`

## Test plan
- [ ] Daily Brief appears in the Meeting Assistant nav group
- [ ] Page renders correctly with video, steps, and card links