### PR TITLE
Reduce dark logo display width

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -14,7 +14,8 @@
   "favicon": "/favicon.png",
   "logo": {
     "light": "/logo/light.svg",
-    "dark": "/logo/dark.png"
+    "dark": "/logo/dark.png",
+    "width": 100
   },
   "navbar": {
     "links": [


### PR DESCRIPTION
## Summary
- Set dark logo `width` to 100px in `docs.json` to make it slightly smaller in the nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)