### PR TITLE
Round video edges on label instructions

### DIFF
--- a/features/inbox-management/email-triage.mdx
+++ b/features/inbox-management/email-triage.mdx
@@ -41,7 +41,17 @@ You can customize these categories: add new ones, remove existing ones, or reord
 
 ### Adding a Label
 
-<video src="/lindy-brand-assets/label_instr.mp4" autoPlay muted loop />
+<div className="video-card">
+  <video
+    src="/lindy-brand-assets/label_instr.mp4"
+    width="600"
+    autoPlay
+    muted
+    loop
+    playsInline
+    style={{ display: 'block', width: '100%', borderRadius: '16px' }}
+  />
+</div>
 
 <Steps>
   <Step title="Open the Email Labeling section">


### PR DESCRIPTION
## Summary
- Wraps the `label_instr.mp4` video in a `video-card` div with `borderRadius: '16px'` to match the rounded video style used across other feature pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)