### PR TITLE
Make label instructions video full width

### DIFF
--- a/features/inbox-management/email-triage.mdx
+++ b/features/inbox-management/email-triage.mdx
@@ -41,10 +41,9 @@ You can customize these categories: add new ones, remove existing ones, or reord
 
 ### Adding a Label
 
-<div className="video-card">
+<div className="video-card" style={{ display: 'block', width: '100%' }}>
   <video
     src="/lindy-brand-assets/label_instr.mp4"
-    width="600"
     autoPlay
     muted
     loop


### PR DESCRIPTION
## Summary
- Sets `display: block; width: 100%` on the video-card wrapper so the video fills the full content width instead of shrinking to its natural size

🤖 Generated with [Claude Code](https://claude.com/claude-code)