### PR TITLE
Fix label video black bars

### DIFF
--- a/features/inbox-management/email-triage.mdx
+++ b/features/inbox-management/email-triage.mdx
@@ -41,14 +41,14 @@ You can customize these categories: add new ones, remove existing ones, or reord
 
 ### Adding a Label
 
-<div className="video-card" style={{ display: 'block', width: '100%' }}>
+<div style={{ width: '100%', borderRadius: '16px', overflow: 'hidden' }}>
   <video
     src="/lindy-brand-assets/label_instr.mp4"
     autoPlay
     muted
     loop
     playsInline
-    style={{ display: 'block', width: '100%', borderRadius: '16px' }}
+    style={{ display: 'block', width: '100%', height: 'auto' }}
   />
 </div>
 


### PR DESCRIPTION
## Summary
- Replaces `video-card` class wrapper with a plain div using inline styles
- The `.video-card video { width: auto !important }` CSS rule was overriding `width: 100%`, leaving the video at its natural width with black gaps on the sides
- Plain div with `overflow: hidden; border-radius: 16px` and video with `width: 100%; height: auto` ensures the video scales to full content width with no black bars

🤖 Generated with [Claude Code](https://claude.com/claude-code)