### PR TITLE
Fix label video size and rounded edges

### DIFF
--- a/features/inbox-management/email-triage.mdx
+++ b/features/inbox-management/email-triage.mdx
@@ -48,7 +48,7 @@ You can customize these categories: add new ones, remove existing ones, or reord
     muted
     loop
     playsInline
-    style={{ display: 'block', width: '100%', height: 'auto' }}
+    style={{ display: 'block', width: '100%', height: 'auto', maxHeight: 'none', borderRadius: '16px' }}
   />
 </div>
 


### PR DESCRIPTION
## Summary
- Adds `maxHeight: 'none'` inline to override the global `max-height: 350px` CSS rule that was constraining the portrait video into a wide container and causing black side bars
- Adds `borderRadius: '16px'` inline on the video element for explicit rounded corners

🤖 Generated with [Claude Code](https://claude.com/claude-code)