### PR TITLE
Add Team Setup page under Start Here

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -42,6 +42,7 @@
               "pricing",
               "start-here/quickstart",
               "start-here/best-practices",
+              "start-here/team-setup",
               "account-billing/multi-account"
             ]
           },

--- a/start-here/team-setup.mdx
+++ b/start-here/team-setup.mdx
@@ -1,0 +1,39 @@
+---
+title: 'Team Setup'
+description: 'Invite your team, add shared context, and configure workspace controls'
+icon: 'users'
+keywords: ['team', 'invite', 'members', 'workspace', 'admin', 'controls', 'groups', 'roles', 'organization']
+---
+
+## Invite Team Members
+
+<Steps>
+  <Step title="Open Members & Groups">
+    Go to **Settings** then **Members and Groups**.
+  </Step>
+  <Step title="Add a member">
+    Click **Add Member**, enter their email address, and choose their **role** and **group**.
+  </Step>
+</Steps>
+
+## Add Workspace Context
+
+Go to **Settings** then **Workspace Settings**. You can add workspace context directly on this page.
+
+Workspace context lets admins share information across the entire organization. Every Lindy assistant in your workspace comes pre-equipped with that context, so your team never has to repeat the same background in their own setups.
+
+<Tip>
+Use workspace context for things like company description, tone guidelines, key contacts, or internal processes — anything your whole team's Lindy should already know.
+</Tip>
+
+## Admin Controls
+
+Also in **Settings** then **Workspace Settings**, admins can control which features are available to users across the workspace.
+
+| Feature | What It Controls |
+|---|---|
+| **Meeting Recording** | Allow users to record meetings and generate summaries |
+| **Email Drafting** | Allow users to have Lindy draft replies in their voice |
+| **Email Triaging** | Allow users to have Lindy triage and prioritize their inbox |
+
+Toggle each feature on or off to manage access for your entire workspace.


### PR DESCRIPTION
## Summary
- Adds new `start-here/team-setup.mdx` page covering team onboarding in 3 sections: Invite Team Members, Add Workspace Context, and Admin Controls
- Registers the page in `docs.json` nav under the Start Here group

## Test plan
- [ ] Preview locally with `mintlify dev` and confirm page renders under Start Here
- [ ] Verify the three sections display correctly (Steps, Tip callout, table)
- [ ] Check nav order: Quickstart → Best Practices → Team Setup → Multi-Account

🤖 Generated with [Claude Code](https://claude.com/claude-code)