### PR TITLE
Reorder workspace context section on Team Setup page

### DIFF
--- a/start-here/team-setup.mdx
+++ b/start-here/team-setup.mdx
@@ -18,9 +18,9 @@ keywords: ['team', 'invite', 'members', 'workspace', 'admin', 'controls', 'group
 
 ## Add Workspace Context
 
-Go to **Settings** then **Workspace Settings**. You can add workspace context directly on this page.
-
 Workspace context lets admins share information across the entire organization. Every Lindy assistant in your workspace comes pre-equipped with that context, so your team never has to repeat the same background in their own setups.
+
+Go to **Settings** then **Workspace Settings**. You can add workspace context directly on this page.
 
 <Tip>
 Use workspace context for things like company description, tone guidelines, key contacts, or internal processes — anything your whole team's Lindy should already know.


### PR DESCRIPTION
## Summary
- Flips the workspace context section so the description of what it does comes before the navigation instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)