### PR TITLE
Wrap context video in Frame for full-width display

### DIFF
--- a/start-here/team-setup.mdx
+++ b/start-here/team-setup.mdx
@@ -32,7 +32,9 @@ Go to **Settings** and choose the **Settings** option under Workspace.
 
 Here's an example of workspace context in action:
 
-<video src="/lindy-brand-assets/context.mp4" autoPlay muted loop playsInline style={{ width: '100%', borderRadius: '12px' }} />
+<Frame>
+  <video src="/lindy-brand-assets/context.mp4" autoPlay muted loop playsInline style={{ borderRadius: '12px' }} />
+</Frame>
 
 <Tip>
 Use workspace context for things like company description, tone guidelines, key contacts, or internal processes — anything your whole team's Lindy should already know.


### PR DESCRIPTION
## Summary
- Wraps `context.mp4` in `<Frame>` so it fills the full content width (same as images on the page)
- Keeps `border-radius: 12px` for rounded edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)