### PR TITLE
Make context video full width, remove black bars

### DIFF
--- a/start-here/team-setup.mdx
+++ b/start-here/team-setup.mdx
@@ -33,7 +33,7 @@ Go to **Settings** and choose the **Settings** option under Workspace.
 Here's an example of workspace context in action:
 
 <Frame>
-  <video src="/lindy-brand-assets/context2.mp4" autoPlay muted loop playsInline style={{ borderRadius: '12px' }} />
+  <video src="/lindy-brand-assets/context2.mp4" autoPlay muted loop playsInline style={{ borderRadius: '12px', width: '100%', display: 'block' }} />
 </Frame>
 
 <Tip>


### PR DESCRIPTION
## Summary
- Adds `width: 100%` and `display: block` to the context video on the team-setup page
- Removes side black bars and makes the video fill the full container width

🤖 Generated with [Claude Code](https://claude.com/claude-code)