### PR TITLE
Remove Frame wrapper from context video to fill full width

### DIFF
--- a/start-here/team-setup.mdx
+++ b/start-here/team-setup.mdx
@@ -32,9 +32,7 @@ Go to **Settings** and choose the **Settings** option under Workspace.
 
 Here's an example of workspace context in action:
 
-<Frame>
-  <video src="/lindy-brand-assets/context2.mp4" autoPlay muted loop playsInline style={{ borderRadius: '12px', width: '100%', display: 'block' }} />
-</Frame>
+<video src="/lindy-brand-assets/context2.mp4" autoPlay muted loop playsInline style={{ borderRadius: '12px', width: '100%', display: 'block' }} />
 
 <Tip>
 Use workspace context for things like company description, tone guidelines, key contacts, or internal processes — anything your whole team's Lindy should already know.


### PR DESCRIPTION
## Summary
- Removes the `<Frame>` wrapper around the context video on the team-setup page
- The Frame component was constraining the video width and causing side black bars
- Video now renders at full content width

🤖 Generated with [Claude Code](https://claude.com/claude-code)