### PR TITLE
Make context video bigger with rounded corners, remove black bars

### DIFF
--- a/start-here/team-setup.mdx
+++ b/start-here/team-setup.mdx
@@ -32,7 +32,9 @@ Go to **Settings** and choose the **Settings** option under Workspace.
 
 Here's an example of workspace context in action:
 
-<video src="/lindy-brand-assets/context2.mp4" autoPlay muted loop playsInline style={{ borderRadius: '12px', width: '100%', display: 'block' }} />
+<div style={{ borderRadius: '20px', overflow: 'hidden' }}>
+  <video src="/lindy-brand-assets/context2.mp4" autoPlay muted loop playsInline style={{ width: '100%', display: 'block', maxHeight: 'none' }} />
+</div>
 
 <Tip>
 Use workspace context for things like company description, tone guidelines, key contacts, or internal processes — anything your whole team's Lindy should already know.


### PR DESCRIPTION
## Summary
- Wraps video in a `div` with `border-radius: 20px` and `overflow: hidden` so corners are properly clipped
- Adds `maxHeight: none` to override the global `max-height: 350px` CSS rule that was forcing a constrained box and causing side black bars

🤖 Generated with [Claude Code](https://claude.com/claude-code)