### PR TITLE
Increase multi-account images from 550 to 700px wide

### DIFF
--- a/account-billing/multi-account.mdx
+++ b/account-billing/multi-account.mdx
@@ -19,7 +19,7 @@ You can add additional accounts from two places in the sidebar:
 4. Follow the prompts to sign in and grant Lindy access
 
 <Frame>
-  <img src="/lindy-brand-assets/emails-add-account-white.png" alt="Emails add account" width="550" />
+  <img src="/lindy-brand-assets/emails-add-account-white.png" alt="Emails add account" width="700" />
 </Frame>
 
 ### Meetings
@@ -30,7 +30,7 @@ You can add additional accounts from two places in the sidebar:
 4. Follow the prompts to sign in and grant Lindy access
 
 <Frame>
-  <img src="/lindy-brand-assets/meetings-add-account-white.png" alt="Meetings add account" width="550" />
+  <img src="/lindy-brand-assets/meetings-add-account-white.png" alt="Meetings add account" width="700" />
 </Frame>
 
 <Note>


### PR DESCRIPTION
## Summary
- Bumps both add-account images from `width="550"` to `width="700"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)