### PR TITLE
Replace community link with group onboarding session

### DIFF
--- a/fundamentals/lindy-101/introduction.mdx
+++ b/fundamentals/lindy-101/introduction.mdx
@@ -175,6 +175,6 @@ Ready to create your first custom workflow? Here's how to get started:
   </Card>
 </CardGroup>
 
-<Card title="Community" href="https://community.lindy.ai/join" icon="users">
+<Card title="Join a group onboarding session" href="https://luma.com/getlindy" icon="users">
   Connect with other advanced users, ask questions, and share what you've built with Lindy
 </Card>


### PR DESCRIPTION
## Summary
- Replaces `Community: community.lindy.ai` card with `Join a group onboarding session: https://luma.com/getlindy` on the What is Lindy page (`fundamentals/lindy-101/introduction.mdx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)