### PR TITLE
Replace community link with group onboarding session in Need Help section

### DIFF
--- a/index.mdx
+++ b/index.mdx
@@ -85,4 +85,4 @@ Lindy takes your data seriously. Your information is encrypted, never sold, and 
 ## Need Help?
 
 - **Email:** [support@lindy.ai](mailto:support@lindy.ai)
-- **Community:** [community.lindy.ai](https://community.lindy.ai)
+- **Join a group onboarding session:** [luma.com/getlindy](https://luma.com/getlindy)


### PR DESCRIPTION
## Summary
- Replaces `Community: community.lindy.ai` with `Join a group onboarding session: https://luma.com/getlindy` in the Need Help section of `index.mdx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)