### PR TITLE
Make scheduling step images full width

### DIFF
--- a/features/meeting-assistant/scheduling.mdx
+++ b/features/meeting-assistant/scheduling.mdx
@@ -30,21 +30,21 @@ You say who and when. Lindy finds the time, sends the invite, and puts it on you
     When someone reaches out asking when you're free, Lindy detects the scheduling request and takes over — no action needed from you.
 
     <Frame>
-      <img src="/lindy-brand-assets/scheduling1.png" alt="Incoming email requesting a meeting" />
+      <img src="/lindy-brand-assets/scheduling1.png" alt="Incoming email requesting a meeting" style={{ width: '100%' }} />
     </Frame>
   </Step>
   <Step title="Lindy replies with 3 available times">
     Based on the conditions you've set in your Lindy Smart Scheduling section — your preferred hours, buffer time, meeting length, and calendar availability — Lindy automatically replies with 3 open slots as clickable links.
 
     <Frame>
-      <img src="/lindy-brand-assets/scheduling2.png" alt="Lindy's reply with 3 available time slots" />
+      <img src="/lindy-brand-assets/scheduling2.png" alt="Lindy's reply with 3 available time slots" style={{ width: '100%' }} />
     </Frame>
   </Step>
   <Step title="They click a time and it's instantly booked">
     When the other person clicks a link, the meeting is automatically added to both calendars. No back-and-forth, no scheduling tools, no manual entry.
 
     <Frame>
-      <img src="/lindy-brand-assets/scheduling3.png" alt="Meeting booked on calendar after clicking a time slot" />
+      <img src="/lindy-brand-assets/scheduling3.png" alt="Meeting booked on calendar after clicking a time slot" style={{ width: '100%' }} />
     </Frame>
   </Step>
 </Steps>


### PR DESCRIPTION
## Summary
- Adds `style={{ width: '100%' }}` to all three scheduling step images for a larger display

🤖 Generated with [Claude Code](https://claude.com/claude-code)