### PR TITLE
Fix video sizing on meeting-prep page

### DIFF
--- a/features/meeting-assistant/meeting-prep.mdx
+++ b/features/meeting-assistant/meeting-prep.mdx
@@ -16,7 +16,7 @@ keywords: ['meeting prep', 'briefing', 'agenda', 'preparation']
       muted
       loop
       playsInline
-      style={{ display: 'block', width: '100%', borderRadius: '16px' }}
+      style={{ display: 'block', width: '100%', borderRadius: '16px', maxHeight: 'none' }}
     />
   </div>
 </div>
@@ -58,7 +58,7 @@ You can customize the prep format in your settings at [chat.lindy.ai](https://ch
       muted
       loop
       playsInline
-      style={{ display: 'block', width: '100%', borderRadius: '16px' }}
+      style={{ display: 'block', width: '100%', borderRadius: '16px', maxHeight: 'none' }}
     />
   </div>
 </div>
@@ -85,7 +85,7 @@ You can enable one or both.
       muted
       loop
       playsInline
-      style={{ display: 'block', width: '100%', borderRadius: '16px' }}
+      style={{ display: 'block', width: '100%', borderRadius: '16px', maxHeight: 'none' }}
     />
   </div>
 </div>


### PR DESCRIPTION
## What this fixes

The three videos on the **Meeting Prep** page were rendering smaller than intended, with empty whitespace on the sides. A global style rule caps every video at 350px tall, which forced these near-square videos to shrink. This change lifts that cap so they fill their intended width.

**Page:** `/features/meeting-assistant/meeting-prep`

## How to fix video sizing yourself (no code needed)

If a video on any docs page looks too small or has whitespace around it, here's the fix:

1. Open the page's `.mdx` file and find the `<video ... />` block.
2. Look at the line that starts with `style={{ ... }}`. It looks like this:

   `style={{ display: 'block', width: '100%', borderRadius: '16px' }}`

3. Add `, maxHeight: 'none'` just before the closing `}}`:

   `style={{ display: 'block', width: '100%', borderRadius: '16px', maxHeight: 'none' }}`

4. Save and preview. The video now shows at full size.

**Why this happens:** all videos are capped at 350px tall by default. Adding `maxHeight: 'none'` removes that cap for that one video. If you want it taller but not unlimited, use a number instead, e.g. `maxHeight: '540px'`.

**To make a video wider or narrower:** change the `width="600"` number on the `<video>` tag (bigger number = wider).