### PR TITLE
Match scheduling image size to meeting-prep page

### DIFF
--- a/features/meeting-assistant/scheduling.mdx
+++ b/features/meeting-assistant/scheduling.mdx
@@ -29,17 +29,17 @@ You say who and when. Lindy finds the time, sends the invite, and puts it on you
   <Step title="Someone emails you asking for a time to meet">
     When someone reaches out asking when you're free, Lindy detects the scheduling request and takes over: no action needed from you.
 
-    <img src="/lindy-brand-assets/scheduling1.png" alt="Incoming email requesting a meeting" style={{ width: 'calc(100% + 4rem)', marginLeft: '-2rem', borderRadius: '12px' }} />
+    <img src="/lindy-brand-assets/scheduling1.png" alt="Incoming email requesting a meeting" style={{ width: '100%', borderRadius: '12px' }} />
   </Step>
   <Step title="Lindy replies with 3 available times">
     Based on the conditions you've set in your Lindy Smart Scheduling section: your preferred hours, buffer time, meeting length, and calendar availability. Lindy automatically replies with 3 open slots as clickable links.
 
-    <img src="/lindy-brand-assets/schedulingv2.png" alt="Lindy's reply with 3 available time slots" style={{ width: 'calc(100% + 4rem)', marginLeft: '-2rem', borderRadius: '12px' }} />
+    <img src="/lindy-brand-assets/schedulingv2.png" alt="Lindy's reply with 3 available time slots" style={{ width: '100%', borderRadius: '12px' }} />
   </Step>
   <Step title="They click a time and it's instantly booked">
     When the other person clicks a link, the meeting is automatically added to both calendars. No back-and-forth, no scheduling tools, no manual entry.
 
-    <img src="/lindy-brand-assets/scheduling3.png" alt="Meeting booked on calendar after clicking a time slot" style={{ width: 'calc(100% + 4rem)', marginLeft: '-2rem', borderRadius: '12px' }} />
+    <img src="/lindy-brand-assets/scheduling3.png" alt="Meeting booked on calendar after clicking a time slot" style={{ width: '100%', borderRadius: '12px' }} />
   </Step>
 </Steps>
 


### PR DESCRIPTION
## Summary
- Updates scheduling step image styles to match meeting-prep: `width: '100%', borderRadius: '12px'` (removes negative margin override)

🤖 Generated with [Claude Code](https://claude.com/claude-code)