### PR TITLE
Remove maxHeight constraint on scheduling video

### DIFF
--- a/features/meeting-assistant/scheduling.mdx
+++ b/features/meeting-assistant/scheduling.mdx
@@ -16,7 +16,7 @@ keywords: ['scheduling', 'calendar', 'book meeting', 'availability', 'schedule']
       muted
       loop
       playsInline
-      style={{ display: 'block', width: '100%', borderRadius: '16px' }}
+      style={{ display: 'block', width: '100%', borderRadius: '16px', maxHeight: 'none' }}
     />
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Adds `maxHeight: 'none'` to the scheduling video style so it renders at full size

🤖 Generated with [Claude Code](https://claude.com/claude-code)