### PR TITLE
Slightly reduce scheduling video size

### DIFF
--- a/features/meeting-assistant/scheduling.mdx
+++ b/features/meeting-assistant/scheduling.mdx
@@ -8,7 +8,7 @@ keywords: ['scheduling', 'calendar', 'book meeting', 'availability', 'schedule']
 ## Let Lindy Handle Scheduling
 
 <div style={{ display: 'flex', justifyContent: 'center', margin: '2rem 0' }}>
-  <div className="video-card">
+  <div className="video-card" style={{ maxWidth: '85%', width: '100%' }}>
     <video
       src="/lindy-brand-assets/scheduling-find-time.mp4"
       width="600"


### PR DESCRIPTION
## Summary
- Adds `maxWidth: '85%'` to the video wrapper to reduce the video size slightly

🤖 Generated with [Claude Code](https://claude.com/claude-code)