### PR TITLE
Fix redirect loop: remove duplicate page entries in docs.json

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -42,8 +42,7 @@
               "pricing",
               "start-here/quickstart",
               "start-here/best-practices",
-              "start-here/team-setup",
-              "account-billing/multi-account"
+              "start-here/team-setup"
             ]
           },
           {
@@ -124,10 +123,8 @@
           {
             "group": "Accounts & Billing",
             "pages": [
-              "account-billing/usage",
               "account-billing/teams-collaboration",
-              "account-billing/credits",
-              "account-billing/multi-account"
+              "account-billing/credits"
             ]
           },
           {


### PR DESCRIPTION
## Summary
- `account-billing/multi-account` and `account-billing/usage` were registered in multiple navigation groups, causing Mintlify's router to produce a redirect loop
- Removed `account-billing/multi-account` from Documentation > Start Here (kept in Accounts & Billing)
- Removed `account-billing/usage` and `account-billing/multi-account` from Workflows > Accounts & Billing (kept unique entries: teams-collaboration, credits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)