### PR TITLE
Increase scheduling images to 115% width

### DIFF
--- a/features/meeting-assistant/scheduling.mdx
+++ b/features/meeting-assistant/scheduling.mdx
@@ -31,7 +31,7 @@ You say who and when. Lindy finds the time, sends the invite, and puts it on you
   </Step>
 </Steps>
 
-<img src="/lindy-brand-assets/scheduling1.png" alt="Incoming email requesting a meeting" style={{ display: 'block', width: '100%', maxWidth: 'none', maxHeight: 'none', borderRadius: '12px', marginBottom: '2rem' }} />
+<img src="/lindy-brand-assets/scheduling1.png" alt="Incoming email requesting a meeting" style={{ display: 'block', width: '115%', marginLeft: '-7.5%', maxWidth: 'none', maxHeight: 'none', borderRadius: '12px', marginBottom: '2rem' }} />
 
 <Steps start={2}>
   <Step title="Lindy replies with 3 available times">
@@ -39,7 +39,7 @@ You say who and when. Lindy finds the time, sends the invite, and puts it on you
   </Step>
 </Steps>
 
-<img src="/lindy-brand-assets/schedulingv2.png" alt="Lindy's reply with 3 available time slots" style={{ display: 'block', width: '100%', maxWidth: 'none', maxHeight: 'none', borderRadius: '12px', marginBottom: '2rem' }} />
+<img src="/lindy-brand-assets/schedulingv2.png" alt="Lindy's reply with 3 available time slots" style={{ display: 'block', width: '115%', marginLeft: '-7.5%', maxWidth: 'none', maxHeight: 'none', borderRadius: '12px', marginBottom: '2rem' }} />
 
 <Steps start={3}>
   <Step title="They click a time and it's instantly booked">
@@ -47,7 +47,7 @@ You say who and when. Lindy finds the time, sends the invite, and puts it on you
   </Step>
 </Steps>
 
-<img src="/lindy-brand-assets/scheduling3.png" alt="Meeting booked on calendar after clicking a time slot" style={{ display: 'block', width: '100%', maxWidth: 'none', maxHeight: 'none', borderRadius: '12px', marginBottom: '2rem' }} />
+<img src="/lindy-brand-assets/scheduling3.png" alt="Meeting booked on calendar after clicking a time slot" style={{ display: 'block', width: '115%', marginLeft: '-7.5%', maxWidth: 'none', maxHeight: 'none', borderRadius: '12px', marginBottom: '2rem' }} />
 
 ## Rescheduling & Changes
 


### PR DESCRIPTION
## Summary
- Bumps scheduling step images to `width: 115%, marginLeft: -7.5%` for a slightly larger display

🤖 Generated with [Claude Code](https://claude.com/claude-code)