### PR TITLE
Fix step numbering on Smart Scheduling page

### DIFF
--- a/features/meeting-assistant/scheduling.mdx
+++ b/features/meeting-assistant/scheduling.mdx
@@ -25,27 +25,21 @@ You say who and when. Lindy finds the time, sends the invite, and puts it on you
 
 ## How It Works
 
-<Steps>
-  <Step title="Someone emails you asking for a time to meet">
-    When someone reaches out asking when you're free, Lindy detects the scheduling request and takes over: no action needed from you.
-  </Step>
-</Steps>
+**1. Someone emails you asking for a time to meet**
+
+When someone reaches out asking when you're free, Lindy detects the scheduling request and takes over: no action needed from you.
 
 <img src="/lindy-brand-assets/scheduling1.png" alt="Incoming email requesting a meeting" style={{ display: 'block', width: '115%', marginLeft: '-7.5%', maxWidth: 'none', maxHeight: 'none', borderRadius: '12px', marginBottom: '2rem' }} />
 
-<Steps start={2}>
-  <Step title="Lindy replies with 3 available times">
-    Based on the conditions you've set in your Lindy Smart Scheduling section: your preferred hours, buffer time, meeting length, and calendar availability. Lindy automatically replies with 3 open slots as clickable links.
-  </Step>
-</Steps>
+**2. Lindy replies with 3 available times**
+
+Based on the conditions you've set in your Lindy Smart Scheduling section: your preferred hours, buffer time, meeting length, and calendar availability. Lindy automatically replies with 3 open slots as clickable links.
 
 <img src="/lindy-brand-assets/schedulingv2.png" alt="Lindy's reply with 3 available time slots" style={{ display: 'block', width: '115%', marginLeft: '-7.5%', maxWidth: 'none', maxHeight: 'none', borderRadius: '12px', marginBottom: '2rem' }} />
 
-<Steps start={3}>
-  <Step title="They click a time and it's instantly booked">
-    When the other person clicks a link, the meeting is automatically added to both calendars. No back-and-forth, no scheduling tools, no manual entry.
-  </Step>
-</Steps>
+**3. They click a time and it's instantly booked**
+
+When the other person clicks a link, the meeting is automatically added to both calendars. No back-and-forth, no scheduling tools, no manual entry.
 
 <img src="/lindy-brand-assets/scheduling3.png" alt="Meeting booked on calendar after clicking a time slot" style={{ display: 'block', width: '115%', marginLeft: '-7.5%', maxWidth: 'none', maxHeight: 'none', borderRadius: '12px', marginBottom: '2rem' }} />
 


### PR DESCRIPTION
## Summary
- Mintlify's `<Steps>` component doesn't support a `start` prop so each block reset to 1
- Replaces three separate `<Steps>` blocks with bold numbered headings (1. 2. 3.) so numbering is correct and images stay at full width

🤖 Generated with [Claude Code](https://claude.com/claude-code)