### PR TITLE
Restore Steps format with images inside single Steps block

### DIFF
--- a/features/meeting-assistant/scheduling.mdx
+++ b/features/meeting-assistant/scheduling.mdx
@@ -25,23 +25,23 @@ You say who and when. Lindy finds the time, sends the invite, and puts it on you
 
 ## How It Works
 
-**1. Someone emails you asking for a time to meet**
+<Steps>
+  <Step title="Someone emails you asking for a time to meet">
+    When someone reaches out asking when you're free, Lindy detects the scheduling request and takes over: no action needed from you.
 
-When someone reaches out asking when you're free, Lindy detects the scheduling request and takes over: no action needed from you.
+    <img src="/lindy-brand-assets/scheduling1.png" alt="Incoming email requesting a meeting" style={{ display: 'block', width: '100%', maxWidth: 'none', maxHeight: 'none', borderRadius: '12px' }} />
+  </Step>
+  <Step title="Lindy replies with 3 available times">
+    Based on the conditions you've set in your Lindy Smart Scheduling section: your preferred hours, buffer time, meeting length, and calendar availability. Lindy automatically replies with 3 open slots as clickable links.
 
-<img src="/lindy-brand-assets/scheduling1.png" alt="Incoming email requesting a meeting" style={{ display: 'block', width: '115%', marginLeft: '-7.5%', maxWidth: 'none', maxHeight: 'none', borderRadius: '12px', marginBottom: '2rem' }} />
+    <img src="/lindy-brand-assets/schedulingv2.png" alt="Lindy's reply with 3 available time slots" style={{ display: 'block', width: '100%', maxWidth: 'none', maxHeight: 'none', borderRadius: '12px' }} />
+  </Step>
+  <Step title="They click a time and it's instantly booked">
+    When the other person clicks a link, the meeting is automatically added to both calendars. No back-and-forth, no scheduling tools, no manual entry.
 
-**2. Lindy replies with 3 available times**
-
-Based on the conditions you've set in your Lindy Smart Scheduling section: your preferred hours, buffer time, meeting length, and calendar availability. Lindy automatically replies with 3 open slots as clickable links.
-
-<img src="/lindy-brand-assets/schedulingv2.png" alt="Lindy's reply with 3 available time slots" style={{ display: 'block', width: '115%', marginLeft: '-7.5%', maxWidth: 'none', maxHeight: 'none', borderRadius: '12px', marginBottom: '2rem' }} />
-
-**3. They click a time and it's instantly booked**
-
-When the other person clicks a link, the meeting is automatically added to both calendars. No back-and-forth, no scheduling tools, no manual entry.
-
-<img src="/lindy-brand-assets/scheduling3.png" alt="Meeting booked on calendar after clicking a time slot" style={{ display: 'block', width: '115%', marginLeft: '-7.5%', maxWidth: 'none', maxHeight: 'none', borderRadius: '12px', marginBottom: '2rem' }} />
+    <img src="/lindy-brand-assets/scheduling3.png" alt="Meeting booked on calendar after clicking a time slot" style={{ display: 'block', width: '100%', maxWidth: 'none', maxHeight: 'none', borderRadius: '12px' }} />
+  </Step>
+</Steps>
 
 ## Rescheduling & Changes
 


### PR DESCRIPTION
## Summary
- Puts all three steps back into a single `<Steps>` block so numbering shows 1, 2, 3 correctly
- Images fill the full step content width at 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)