### PR TITLE
Replace Steps with Cards + number icons on scheduling page

### DIFF
--- a/features/meeting-assistant/scheduling.mdx
+++ b/features/meeting-assistant/scheduling.mdx
@@ -25,23 +25,23 @@ You say who and when. Lindy finds the time, sends the invite, and puts it on you
 
 ## How It Works
 
-<Steps>
-  <Step title="Someone emails you asking for a time to meet">
-    When someone reaches out asking when you're free, Lindy detects the scheduling request and takes over: no action needed from you.
+<Card title="Someone emails you asking for a time to meet" icon="circle-1">
+  When someone reaches out asking when you're free, Lindy detects the scheduling request and takes over: no action needed from you.
+</Card>
 
-    <img src="/lindy-brand-assets/scheduling1.png" alt="Incoming email requesting a meeting" style={{ display: 'block', width: '100%', maxWidth: 'none', maxHeight: 'none', borderRadius: '12px' }} />
-  </Step>
-  <Step title="Lindy replies with 3 available times">
-    Based on the conditions you've set in your Lindy Smart Scheduling section: your preferred hours, buffer time, meeting length, and calendar availability. Lindy automatically replies with 3 open slots as clickable links.
+<img src="/lindy-brand-assets/scheduling1.png" alt="Incoming email requesting a meeting" style={{ display: 'block', width: '115%', marginLeft: '-7.5%', maxWidth: 'none', maxHeight: 'none', borderRadius: '12px', margin: '1.5rem 0 1.5rem -7.5%' }} />
 
-    <img src="/lindy-brand-assets/schedulingv2.png" alt="Lindy's reply with 3 available time slots" style={{ display: 'block', width: '100%', maxWidth: 'none', maxHeight: 'none', borderRadius: '12px' }} />
-  </Step>
-  <Step title="They click a time and it's instantly booked">
-    When the other person clicks a link, the meeting is automatically added to both calendars. No back-and-forth, no scheduling tools, no manual entry.
+<Card title="Lindy replies with 3 available times" icon="circle-2">
+  Based on the conditions you've set in your Lindy Smart Scheduling section: your preferred hours, buffer time, meeting length, and calendar availability. Lindy automatically replies with 3 open slots as clickable links.
+</Card>
 
-    <img src="/lindy-brand-assets/scheduling3.png" alt="Meeting booked on calendar after clicking a time slot" style={{ display: 'block', width: '100%', maxWidth: 'none', maxHeight: 'none', borderRadius: '12px' }} />
-  </Step>
-</Steps>
+<img src="/lindy-brand-assets/schedulingv2.png" alt="Lindy's reply with 3 available time slots" style={{ display: 'block', width: '115%', marginLeft: '-7.5%', maxWidth: 'none', maxHeight: 'none', borderRadius: '12px', margin: '1.5rem 0 1.5rem -7.5%' }} />
+
+<Card title="They click a time and it's instantly booked" icon="circle-3">
+  When the other person clicks a link, the meeting is automatically added to both calendars. No back-and-forth, no scheduling tools, no manual entry.
+</Card>
+
+<img src="/lindy-brand-assets/scheduling3.png" alt="Meeting booked on calendar after clicking a time slot" style={{ display: 'block', width: '115%', marginLeft: '-7.5%', maxWidth: 'none', maxHeight: 'none', borderRadius: '12px', margin: '1.5rem 0 1.5rem -7.5%' }} />
 
 ## Rescheduling & Changes
 


### PR DESCRIPTION
## Summary
- Replaces `<Steps>` component with individual `<Card>` components using `circle-1/2/3` icons
- Images sit outside the Card containers so they render at full 115% width

🤖 Generated with [Claude Code](https://claude.com/claude-code)