### PR TITLE
Update scheduling step 2 image to schedulev3.png

### DIFF
--- a/features/meeting-assistant/scheduling.mdx
+++ b/features/meeting-assistant/scheduling.mdx
@@ -34,7 +34,7 @@ You say who and when. Lindy finds the time, sends the invite, and puts it on you
   <Step title="Lindy replies with 3 available times">
     Based on the conditions you've set in your Lindy Smart Scheduling section: your preferred hours, buffer time, meeting length, and calendar availability. Lindy automatically replies with 3 open slots as clickable links.
 
-    <img src="/lindy-brand-assets/schedulingv2.png" alt="Lindy's reply with 3 available time slots" style={{ display: 'block', width: '100%', maxWidth: 'none', maxHeight: 'none', borderRadius: '12px' }} />
+    <img src="/lindy-brand-assets/schedulev3.png" alt="Lindy's reply with 3 available time slots" style={{ display: 'block', width: '100%', maxWidth: 'none', maxHeight: 'none', borderRadius: '12px' }} />
   </Step>
   <Step title="They click a time and it's instantly booked">
     When the other person clicks a link, the meeting is automatically added to both calendars. No back-and-forth, no scheduling tools, no manual entry.


### PR DESCRIPTION
## Summary
- Replaces `schedulingv2.png` with `schedulev3.png` in the "Lindy replies with 3 available times" step on the Smart Scheduling page

## Test plan
- [ ] Verify the new image renders correctly on the scheduling page preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)