### PR TITLE
Replace step 1 image with chatv1.png on scheduling page

### DIFF
--- a/features/meeting-assistant/scheduling.mdx
+++ b/features/meeting-assistant/scheduling.mdx
@@ -29,7 +29,7 @@ You say who and when. Lindy finds the time, sends the invite, and puts it on you
   <Step title="Someone emails you asking for a time to meet">
     When someone reaches out asking when you're free, Lindy detects the scheduling request and takes over: no action needed from you.
 
-    <img src="/lindy-brand-assets/scheduling1.png" alt="Incoming email requesting a meeting" style={{ display: 'block', width: '100%', maxWidth: 'none', maxHeight: 'none', borderRadius: '12px' }} />
+    <img src="/lindy-brand-assets/chatv1.png" alt="Incoming email requesting a meeting" style={{ display: 'block', width: '100%', maxWidth: 'none', maxHeight: 'none', borderRadius: '12px' }} />
   </Step>
   <Step title="Lindy replies with 3 available times">
     Based on the conditions you've set in your Lindy Smart Scheduling section: your preferred hours, buffer time, meeting length, and calendar availability. Lindy automatically replies with 3 open slots as clickable links.


### PR DESCRIPTION
## Summary
- Replaces `scheduling1.png` with `chatv1.png` under the "Someone emails you asking for a time to meet" step on the Smart Scheduling page

🤖 Generated with [Claude Code](https://claude.com/claude-code)