### PR TITLE
Add Common Scenarios section to scheduling page

### DIFF
--- a/features/meeting-assistant/scheduling.mdx
+++ b/features/meeting-assistant/scheduling.mdx
@@ -43,6 +43,20 @@ You say who and when. Lindy finds the time, sends the invite, and puts it on you
   </Step>
 </Steps>
 
+## Common Scenarios
+
+<CardGroup cols={1}>
+  <Card title="When the time is already picked" icon="calendar-check">
+    Text Lindy with the date, time, location or virtual link, and invitees. She'll put it on your calendar. Faster than logging in, especially when you're traveling.
+  </Card>
+  <Card title="When the time isn't picked yet" icon="calendar-clock">
+    Use the Lindy Scheduling Agent. She has her own email address. Copy her on the thread and she'll handle the back-and-forth with all parties. Give her parameters if you want ("only the week of X") or leave it open.
+  </Card>
+  <Card title="Internal availability" icon="users">
+    Lindy can check any teammate's calendar that's shared with the company. Ask via dashboard or text, be specific about who and when, and she'll find a time.
+  </Card>
+</CardGroup>
+
 ## Rescheduling & Changes
 
 Plans change. Text Lindy "Move my 2pm to Thursday" or "Cancel my call with [name]" and it handles the update, notifies attendees, and adjusts your calendar. No need to dig through calendar apps or send apology emails yourself.


### PR DESCRIPTION
## Summary
- Adds a new "Common Scenarios" section with 3 cards covering: time already picked, time not picked yet, and internal availability checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)