### PR TITLE
Convert Common Scenarios from cards to accordions

### DIFF
--- a/features/meeting-assistant/scheduling.mdx
+++ b/features/meeting-assistant/scheduling.mdx
@@ -45,17 +45,17 @@ You say who and when. Lindy finds the time, sends the invite, and puts it on you
 
 ## Common Scenarios
 
-<CardGroup cols={1}>
-  <Card title="When the time is already picked" icon="calendar-check">
+<AccordionGroup>
+  <Accordion title="When the time is already picked">
     Text Lindy with the date, time, location or virtual link, and invitees. She'll put it on your calendar. Faster than logging in, especially when you're traveling.
-  </Card>
-  <Card title="When the time isn't picked yet" icon="calendar-clock">
+  </Accordion>
+  <Accordion title="When the time isn't picked yet">
     Use the Lindy Scheduling Agent. She has her own email address. Copy her on the thread and she'll handle the back-and-forth with all parties. Give her parameters if you want ("only the week of X") or leave it open.
-  </Card>
-  <Card title="Internal availability" icon="users">
+  </Accordion>
+  <Accordion title="Internal availability">
     Lindy can check any teammate's calendar that's shared with the company. Ask via dashboard or text, be specific about who and when, and she'll find a time.
-  </Card>
-</CardGroup>
+  </Accordion>
+</AccordionGroup>
 
 ## Rescheduling & Changes
 


### PR DESCRIPTION
## Summary
- Replaces the `CardGroup` with an `AccordionGroup` for the Common Scenarios section on the scheduling page

🤖 Generated with [Claude Code](https://claude.com/claude-code)