### PR TITLE
Round video edges on best-practices page

### DIFF
--- a/start-here/best-practices.mdx
+++ b/start-here/best-practices.mdx
@@ -11,7 +11,7 @@ keywords: ["best practices", "onboarding", "setup", "getting started", "tips", "
 - **Pin Lindy in iMessage** so she's always one tap away
 
 <div style={{ width: '500px', maxWidth: '100%', borderRadius: '16px', overflow: 'hidden', margin: '0 auto' }}>
-  <video src="/lindy-brand-assets/pin_video.mov" autoPlay muted loop playsInline style={{ display: 'block', width: '100%' }} />
+  <video src="/lindy-brand-assets/pin_video.mov" autoPlay muted loop playsInline style={{ display: 'block', width: '100%', borderRadius: '16px' }} />
 </div>
 
 - **Start with a voice note:** brain-dump for 5 minutes like you're briefing a new hire


### PR DESCRIPTION
Adds `borderRadius: '16px'` directly to the `<video>` element on the best-practices page. The wrapper div already had border-radius + overflow hidden, but applying it directly to the video ensures consistent corner clipping across browsers.