### PR TITLE
Fix video rounded edges using clip-path

### DIFF
--- a/start-here/best-practices.mdx
+++ b/start-here/best-practices.mdx
@@ -11,7 +11,7 @@ keywords: ["best practices", "onboarding", "setup", "getting started", "tips", "
 - **Pin Lindy in iMessage** so she's always one tap away
 
 <div style={{ width: '500px', maxWidth: '100%', borderRadius: '16px', overflow: 'hidden', margin: '0 auto' }}>
-  <video src="/lindy-brand-assets/pin_video.mov" autoPlay muted loop playsInline style={{ display: 'block', width: '100%', borderRadius: '16px' }} />
+  <video src="/lindy-brand-assets/pin_video.mov" autoPlay muted loop playsInline style={{ display: 'block', width: '100%', borderRadius: '16px', clipPath: 'inset(0 round 16px)' }} />
 </div>
 
 - **Start with a voice note:** brain-dump for 5 minutes like you're briefing a new hire

--- a/style.css
+++ b/style.css
@@ -594,8 +594,9 @@ video {
   width: 100%;
   height: auto;
   max-height: 350px; /* 50px smaller */
-  border-radius: 16px; /* round edges */
+  border-radius: 16px;
   overflow: hidden;
+  clip-path: inset(0 round 16px);
 }
 
 /* -------- Video Card Highlight -------- */


### PR DESCRIPTION
`border-radius` on `<video>` elements doesn't reliably clip the actual video rendering across browsers — it only affects the element box. This switches to `clip-path: inset(0 round 16px)` which forces the browser to clip the video content itself, fixing the rounded corners on the best-practices page (and globally for all videos).