### PR TITLE
Round video corners: clip-path on wrapper div

### DIFF
--- a/start-here/best-practices.mdx
+++ b/start-here/best-practices.mdx
@@ -10,8 +10,8 @@ keywords: ["best practices", "onboarding", "setup", "getting started", "tips", "
 
 - **Pin Lindy in iMessage** so she's always one tap away
 
-<div style={{ width: '500px', maxWidth: '100%', borderRadius: '16px', overflow: 'hidden', margin: '0 auto' }}>
-  <video src="/lindy-brand-assets/pin_video.mov" autoPlay muted loop playsInline style={{ display: 'block', width: '100%', borderRadius: '16px', clipPath: 'inset(0 round 16px)' }} />
+<div style={{ width: '500px', maxWidth: '100%', margin: '0 auto', clipPath: 'inset(0 round 16px)' }}>
+  <video src="/lindy-brand-assets/pin_video.mov" autoPlay muted loop playsInline style={{ display: 'block', width: '100%' }} />
 </div>
 
 - **Start with a voice note:** brain-dump for 5 minutes like you're briefing a new hire


### PR DESCRIPTION
Previous attempts applied clip-path/border-radius to the video element itself, which browsers don't reliably clip. This moves clip-path to the wrapper div instead — clip-path on a container clips all content inside it, including video rendering.