### PR TITLE
Deploy: iMessage troubleshooting — 'Lindy stopped responding'

### DIFF
--- a/features/imessage-sms.mdx
+++ b/features/imessage-sms.mdx
@@ -78,6 +78,15 @@ You can customize recurring tasks like briefings in your settings at [chat.lindy
 
 ## Troubleshooting
 
+### Lindy stopped responding
+
+If Lindy stops replying to your texts, try these two steps in order:
+
+1. **Re-verify your phone number.** Go to [chat.lindy.ai](https://chat.lindy.ai), click your username in the top-left, select **Settings → General**, and delete the phone number shown there. Then re-enter your number and verify with the code Lindy sends you.
+2. **Wake the assistant from your phone.** Open [chat.lindy.ai](https://chat.lindy.ai) in your mobile browser, find your Lindy Assistant's contact card, and tap **"Start a conversation"** to send a quick hello. That refreshes the contact and wakes the assistant back up.
+
+### Not receiving texts
+
 If you're not receiving text messages, ensure your **Preferred Messaging Service** is aligned with your device settings. To update this, in Lindy's web UI, go to **Settings → General → Preferred Messaging Service**.
 
 <Frame>


### PR DESCRIPTION
## Summary
- Adds **Lindy stopped responding** subsection to the iMessage page Troubleshooting (re-verify phone in Settings, then send hello from mobile browser to wake the assistant).
- Reorganizes existing "preferred messaging service" content under a **Not receiving texts** subsection.

Previewed on pivot staging: https://lindyai-pivot.mintlify.app/features/imessage-sms#troubleshooting

🤖 Generated with [Claude Code](https://claude.com/claude-code)