### PR TITLE
Make Pro/Max pricing bullets consistently bold-labeled

### DIFF
--- a/pricing.mdx
+++ b/pricing.mdx
@@ -44,11 +44,11 @@ Lindy runs your inbox, meetings, calendar, and follow-ups. Pick the plan that fi
 
     **Everything in Plus, plus:**
     - **3 connected inboxes**: Connect up to 3 email accounts
-    - 3x the usage capacity for heavier workloads
+    - **3x usage capacity**: Built for heavier workloads
     - **Computer use**: Lindy can operate web apps on your behalf
     - **Model selection**: Choose which AI model powers your Lindy
     - **1:1 onboarding session**: Personalized setup with a Lindy specialist
-    - Ideal for managing a busy inbox, back-to-back meetings, and frequent ad hoc tasks
+    - **Built for daily delegation**: Busy inbox, back-to-back meetings, and frequent ad hoc tasks
 
     [Get Pro →](https://lindy.ai)
   </Tab>
@@ -58,8 +58,8 @@ Lindy runs your inbox, meetings, calendar, and follow-ups. Pick the plan that fi
 
     **Everything in Pro, plus:**
     - **5 connected inboxes**: Connect up to 5 email accounts
-    - 7x the usage capacity for the heaviest workloads
-    - Built for all-day delegation across inbox, meetings, research, and more
+    - **7x usage capacity**: Built for the heaviest workloads
+    - **All-day delegation**: Across inbox, meetings, research, and more
 
     [Get Max →](https://lindy.ai)
   </Tab>


### PR DESCRIPTION
## Summary
- Bolds the lead phrase on previously plain bullets so all bullets follow the `**Label**: description` pattern on Pro and Max tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)