### PR TITLE
Promote 'Sent by Lindy' signature to its own section

### DIFF
--- a/features/inbox-management/email-drafting.mdx
+++ b/features/inbox-management/email-drafting.mdx
@@ -36,6 +36,8 @@ The more specific you are, the better Lindy's drafts will sound. You can mention
 
 Lindy learns from your feedback. If a draft isn't quite right, edit it before sending. Lindy picks up on your changes and improves over time.
 
+## "Sent by Lindy" Signature
+
 Every Lindy draft includes a **"Sent by Lindy"** signature by default. You can toggle it off in your settings if you'd rather not include it.
 
 <Frame>


### PR DESCRIPTION
## Summary
- Moves the "Sent by Lindy" signature copy + screenshot out of the tail of **Drafting Instructions** into its own H2 section between Drafting Instructions and Automatic Follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)