### PR TITLE
Expand Signature section: 'Your signature' field + 'Include Sent with Lindy' toggle

### DIFF
--- a/features/inbox-management/email-drafting.mdx
+++ b/features/inbox-management/email-drafting.mdx
@@ -36,12 +36,16 @@ The more specific you are, the better Lindy's drafts will sound. You can mention
 
 Lindy learns from your feedback. If a draft isn't quite right, edit it before sending. Lindy picks up on your changes and improves over time.
 
-## "Sent by Lindy" Signature
+## Signature
 
-Every Lindy draft includes a **"Sent by Lindy"** signature by default. You can toggle it off in your settings if you'd rather not include it.
+Customize what shows up at the bottom of every Lindy draft.
+
+**Your signature** is your standard sign-off, rendered above the Lindy line. Add plain text or markdown — paste in your Gmail signature, or write something new.
+
+**Include Sent with Lindy** adds a small "Sent with Lindy" tagline below your signature. It's on by default — toggle it off in settings if you'd rather not include it.
 
 <Frame>
-  <img src="/lindy-brand-assets/signature.png" alt="Sent by Lindy signature toggle in email drafting settings" />
+  <img src="/lindy-brand-assets/signature.png" alt="Your signature field and Include Sent with Lindy toggle in email drafting settings" />
 </Frame>
 
 ## Automatic Follow-ups


### PR DESCRIPTION
## Summary
- Renames the section from `"Sent by Lindy" Signature` to **Signature** (covers more than the toggle now)
- Describes the **Your signature** field — plain text or markdown, like a Gmail signature, rendered above the Lindy line
- Updates toggle copy to match actual UI label: **"Include Sent with Lindy"** (was "Sent by Lindy")
- Keeps the existing signature.png screenshot which already shows both fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)