### PR TITLE
Move recap iMessage screenshot to follow-ups page

### DIFF
--- a/features/meeting-assistant/follow-ups.mdx
+++ b/features/meeting-assistant/follow-ups.mdx
@@ -8,10 +8,14 @@ keywords: ['follow up', 'action items', 'next steps', 'post meeting']
 ## Nothing Falls Through the Cracks
 
 <Frame>
-  <img src="/lindy-brand-assets/meeting-follow-up-email.jpg" alt="Follow-up email in Gmail showing discussed meeting points and action items" />
+  <img src="/lindy-brand-assets/meeting-recap-imessage.png" alt="Texting Lindy 'Recap my call with Matt' and getting back key takeaways prepared by Lindy" />
 </Frame>
 
 After every meeting, Lindy extracts the action items and sends a follow-up email to attendees. Decisions get documented, next steps are clear, and everyone knows what they're responsible for. Work moves forward without you chasing it.
+
+<Frame>
+  <img src="/lindy-brand-assets/meeting-follow-up-email.jpg" alt="Follow-up email in Gmail showing discussed meeting points and action items" />
+</Frame>
 
 ## How It Works
 

--- a/features/meeting-assistant/meeting-notes.mdx
+++ b/features/meeting-assistant/meeting-notes.mdx
@@ -67,10 +67,6 @@ Your meeting library becomes a knowledge base you can query in plain language â€
 - "What did [name] say about pricing in our last call?"
 - "What did I commit to sending [name]?"
 
-<Frame>
-  <img src="/lindy-brand-assets/meeting-recap-imessage.png" alt="Texting Lindy 'Recap my call with Matt' and getting back key takeaways and action items" />
-</Frame>
-
 The more meetings you record, the richer the context Lindy can draw on.
 
 ## Quick Setup


### PR DESCRIPTION
## Summary
- Removes the "Recap my call with Matt" iMessage image from the **Chat With Your Meetings** section on `/features/meeting-assistant/meeting-notes`.
- Adds it as the lead image on `/features/meeting-assistant/follow-ups` under **Nothing Falls Through the Cracks**, with the existing Gmail follow-up screenshot kept below for the email-channel example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)