### PR TITLE
Style follow-ups Slack DM prompt as purple callout

### DIFF
--- a/features/meeting-assistant/follow-ups.mdx
+++ b/features/meeting-assistant/follow-ups.mdx
@@ -35,11 +35,13 @@ Beyond email, you can tell Lindy to take additional actions after meetings. In y
   <img src="/lindy-brand-assets/follow-up-actions-settings.jpg" alt="Follow-up actions settings showing custom actions and notification options" />
 </Frame>
 
-One of the most-loved follow-ups is having Lindy DM you in Slack right after the meeting ends, with the still-outstanding action items and a heads-up on anything that needs your attention. Try a prompt like:
+One of the most-loved follow-ups is having Lindy DM you in Slack right after the meeting ends, with the still-outstanding action items and a heads-up on anything that needs your attention.
 
-```
+**Try a prompt like:**
+
+<div style={{ background: 'rgba(124, 58, 237, 0.08)', border: '1px solid rgba(124, 58, 237, 0.15)', borderRadius: '8px', padding: '14px 18px', color: '#7C3AED', fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, monospace', fontSize: '0.95em', margin: '12px 0 20px' }}>
 Send a Slack DM with action items
-```
+</div>
 
 <Frame>
   <img src="/lindy-brand-assets/slack-action-items-dm.png" alt="Lindy Slack DM showing 'Action items for your meeting with Matt Pearson' with a 'Still outstanding' checklist and a 'Heads up' note about a reply" />


### PR DESCRIPTION
## Summary
- Splits the Slack DM intro sentence and the prompt onto separate lines.
- Adds a bolded **Try a prompt like:** lead-in on its own line.
- Replaces the plain markdown code fence with a styled callout (light purple background, violet text, monospace, rounded corners) so the prompt visually echoes Lindy's settings-input styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)