### PR TITLE
Deploy: team-setup section reorder

### DIFF
--- a/start-here/team-setup.mdx
+++ b/start-here/team-setup.mdx
@@ -25,34 +25,6 @@ keywords: ['team', 'invite', 'members', 'workspace', 'admin', 'controls', 'group
   </Step>
 </Steps>
 
-## Managing Members
-
-To manage existing members, click your **workspace name in the top-left → Settings → Members and Groups**.
-
-<Frame>
-  <img src="/lindy-brand-assets/Members and groups in settings june 11.png" alt="Workspace settings sidebar showing Settings, Billing, and Members and groups under the Workspace section" />
-</Frame>
-
-### Allocating Credits
-
-Admins and owners can set credit limits for each teammate, capping how many credits they can use each month. Click the **…** menu on a member's row and choose **Edit credit limit**.
-
-<Frame>
-  <img src="/lindy-brand-assets/edit credit limit june 11.png" alt="Members table with per-row menu showing Edit credit limit and Deactivate membership options" />
-</Frame>
-
-<Note>
-We can only stop credit usage after the limit has been exceeded, not at the exact threshold. For example, if a teammate's limit is 100 credits and they've used 90, a task that costs 50 credits will still run to completion — but no further credit usage will be allowed afterward.
-</Note>
-
-### Transferring Workspace Ownership
-
-Owners are the only ones who can manage the payment method, change the workspace name and logo, and delete the workspace. Owners can transfer ownership by clicking the role dropdown next to a member's or admin's name and changing their role to **Owner**.
-
-<Frame>
-  <img src="/lindy-brand-assets/teams3.1.png" alt="Transferring workspace ownership interface" />
-</Frame>
-
 ## Add Workspace Context
 
 Workspace context lets admins share information across the entire organization. Every Lindy assistant in your workspace comes pre-equipped with that context, so your team never has to repeat the same background in their own setups.
@@ -84,3 +56,31 @@ Go to **Settings** and choose the **Settings** option under Workspace.
 | **Meeting Recording** | Allow users to record meetings and generate summaries |
 | **Email Drafting** | Allow users to have Lindy draft replies in their voice |
 | **Email Triaging** | Allow users to have Lindy triage and prioritize their inbox |
+
+## Managing Members
+
+To manage existing members, click your **workspace name in the top-left → Settings → Members and Groups**.
+
+<Frame>
+  <img src="/lindy-brand-assets/Members and groups in settings june 11.png" alt="Workspace settings sidebar showing Settings, Billing, and Members and groups under the Workspace section" />
+</Frame>
+
+### Allocating Credits
+
+Admins and owners can set credit limits for each teammate, capping how many credits they can use each month. Click the **…** menu on a member's row and choose **Edit credit limit**.
+
+<Frame>
+  <img src="/lindy-brand-assets/edit credit limit june 11.png" alt="Members table with per-row menu showing Edit credit limit and Deactivate membership options" />
+</Frame>
+
+<Note>
+We can only stop credit usage after the limit has been exceeded, not at the exact threshold. For example, if a teammate's limit is 100 credits and they've used 90, a task that costs 50 credits will still run to completion — but no further credit usage will be allowed afterward.
+</Note>
+
+### Transferring Workspace Ownership
+
+Owners are the only ones who can manage the payment method, change the workspace name and logo, and delete the workspace. Owners can transfer ownership by clicking the role dropdown next to a member's or admin's name and changing their role to **Owner**.
+
+<Frame>
+  <img src="/lindy-brand-assets/teams3.1.png" alt="Transferring workspace ownership interface" />
+</Frame>


### PR DESCRIPTION
## Summary
- Moves the **Managing Members** section (Members and Groups nav + Allocating Credits + Transferring Workspace Ownership) to the bottom of `/start-here/team-setup`, beneath Admin Controls.

Previewed on staging: https://lindyai-pivot.mintlify.app/start-here/team-setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)