### PR TITLE
follow-ups: add 'Examples' anchor heading above the Slack DM example

### DIFF
--- a/features/meeting-assistant/follow-ups.mdx
+++ b/features/meeting-assistant/follow-ups.mdx
@@ -35,6 +35,8 @@ Beyond email, you can tell Lindy to take additional actions after meetings. In y
   <img src="/lindy-brand-assets/follow-up-actions-settings.jpg" alt="Follow-up actions settings showing custom actions and notification options" />
 </Frame>
 
+### Examples
+
 One of the most-loved follow-ups is having Lindy DM you in Slack right after the meeting ends, with the still-outstanding action items and a heads-up on anything that needs your attention.
 
 **Try a prompt like:**


### PR DESCRIPTION
## Summary
- Adds an **Examples** H3 heading above the Slack DM walkthrough on `/features/meeting-assistant/follow-ups` so the product can deep-link to `#examples`.
- No content reorganization — just inserts the heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)