### PR TITLE
Deploy: 'Examples' anchor heading on follow-ups page

### DIFF
--- a/features/meeting-assistant/follow-ups.mdx
+++ b/features/meeting-assistant/follow-ups.mdx
@@ -35,6 +35,8 @@ Beyond email, you can tell Lindy to take additional actions after meetings. In y
   <img src="/lindy-brand-assets/follow-up-actions-settings.jpg" alt="Follow-up actions settings showing custom actions and notification options" />
 </Frame>
 
+### Examples
+
 One of the most-loved follow-ups is having Lindy DM you in Slack right after the meeting ends, with the still-outstanding action items and a heads-up on anything that needs your attention.
 
 **Try a prompt like:**


### PR DESCRIPTION
## Summary
- Adds **Examples** H3 anchor heading above the Slack DM walkthrough on the follow-ups page so the product can deep-link to `#examples`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)