### PR TITLE
Fix sidebar group selector + bump TOC title size

### DIFF
--- a/style.css
+++ b/style.css
@@ -1485,11 +1485,15 @@ video {
 }
 
 /* ============== SIDEBAR GROUP SPACING ============== */
-/* Tighten the vertical gap between sidebar groups (Start Here, Texting & Tasks, etc.) */
-/* Tailwind utility `mt-8` (2rem) on the group containers was creating very large gaps */
+/* Tighten the vertical gap between sidebar groups (Start Here, Texting & Tasks, etc.)
+   Tailwind utility `mt-8` (2rem) on the group containers was creating very large gaps.
+   The first group wraps in `ul.list-none.mt-8`; subsequent groups wrap in
+   `div.mt-6.lg:mt-8`, so we need both selectors. */
 #sidebar-content ul.list-none.mt-8,
-#sidebar-content ul[class*="mt-8"] {
-  margin-top: 1.25rem !important;
+#sidebar-content ul[class*="mt-8"],
+#sidebar-content div[class*="mt-6"][class*="mt-8"],
+#sidebar-content div[class*="lg:mt-8"] {
+  margin-top: 1rem !important;
 }
 
 /* Slightly tighten the header-to-list gap within a group */
@@ -1502,12 +1506,12 @@ video {
    the right-side "On this page" title, blowing it up to body-heading size. */
 #table-of-contents h2,
 #table-of-contents-layout h2 {
-  font-size: 0.8125rem !important;
+  font-size: 0.95rem !important;
   font-weight: 600 !important;
   line-height: 1.4 !important;
   margin: 0 !important;
   padding: 0 !important;
-  letter-spacing: 0.02em !important;
+  letter-spacing: 0.01em !important;
 }
 
 /* Hide the global h1::after underline indicator if it ever cascades into the TOC */


### PR DESCRIPTION
## Summary
Follow-up to the previous CSS tweak:

- **Sidebar groups** — previous selector only matched the first group's wrapper (`ul.list-none.mt-8`). Subsequent groups (Texting & Tasks, Inbox Management, Meeting Assistant, Accounts & Billing) wrap in `div.mt-6.lg:mt-8`, which wasn't being overridden — so they stayed at the full 2rem gap. Added attribute selectors to cover both patterns.
- **TOC "On this page" title** — was too small at 0.8125rem; bumped to 0.95rem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)