### PR TITLE
best-practices: spacing above Start Small Tip

### DIFF
--- a/start-here/best-practices.mdx
+++ b/start-here/best-practices.mdx
@@ -103,9 +103,11 @@ Tell Lindy the outcome — she'll handle the back-and-forth.
   <img src="/lindy-brand-assets/get-things-out-imessage.png" alt="Texting Lindy 'remind me to call the bank friday — and tell me if Sarah hasn't replied by end of day' and getting back 'got both. i'll ping you friday, and flag Sarah if she's quiet by 5'" />
 </Frame>
 
-<Tip>
-**Start small.** Pick one time sink, let Lindy own it, then keep adding.
-</Tip>
+<div style={{ marginTop: '2.5rem' }}>
+  <Tip>
+    **Start small.** Pick one time sink, let Lindy own it, then keep adding.
+  </Tip>
+</div>
 
 ## Ask Lindy To...
 


### PR DESCRIPTION
## Summary
- Wraps the **Start small.** Tip callout in a div with `marginTop: 2.5rem` so it sits clear of the iMessage screenshot above it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)