### PR TITLE
imessage-sms: place Organize + Send Reminders images side by side

### DIFF
--- a/features/imessage-sms.mdx
+++ b/features/imessage-sms.mdx
@@ -55,10 +55,6 @@ If you skipped the phone number step during signup, you can add it anytime: clic
 - **Prioritize your day**: "What should I focus on today?"
 - **React to changes**: "My 3pm cancelled, what should I do with that time?"
 
-<div style={{ maxWidth: '50%', margin: '1.5rem 0' }}>
-  <img src="/lindy-brand-assets/imessage-organize-prioritize.png" alt="Organize & prioritize — Lindy: 'You're meeting with John from ACME, here's everything you need to know'" style={{ width: '100%', borderRadius: '16px' }} />
-</div>
-
 ### Recurring Tasks
 
 - **Daily briefings**: "Send me a briefing every morning at 7am" (includes your calendar, important emails, weather, and news)
@@ -67,7 +63,8 @@ If you skipped the phone number step during signup, you can add it anytime: clic
 - **Weekly recaps**: "Send me a summary of my week every Friday at 5pm"
 - **CRM updates after meetings**: "Update the CRM after every sales call"
 
-<div style={{ maxWidth: '50%', margin: '1.5rem 0' }}>
+<div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem', margin: '1.5rem 0' }}>
+  <img src="/lindy-brand-assets/imessage-organize-prioritize.png" alt="Organize & prioritize — Lindy: 'You're meeting with John from ACME, here's everything you need to know'" style={{ width: '100%', borderRadius: '16px' }} />
   <img src="/lindy-brand-assets/imessage-send-reminders.png" alt="Send reminders — Lindy: 'Don't forget your pills'" style={{ width: '100%', borderRadius: '16px' }} />
 </div>
 


### PR DESCRIPTION
## Summary
- Removes the half-width image from each of Time & Priorities and Recurring Tasks (they stacked weirdly with section bullets between them).
- Adds a single 2-column grid after Recurring Tasks containing both images side by side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)