### PR TITLE
imessage-sms: move daily-briefing image to bottom of page

### DIFF
--- a/features/imessage-sms.mdx
+++ b/features/imessage-sms.mdx
@@ -68,10 +68,6 @@ If you skipped the phone number step during signup, you can add it anytime: clic
   <img src="/lindy-brand-assets/imessage-send-reminders.png" alt="Send reminders — Lindy: 'Don't forget your pills'" style={{ width: '100%', borderRadius: '16px' }} />
 </div>
 
-<Frame>
-  <img src="/lindy-brand-assets/daily-briefing.jpg" alt="Daily morning briefing from Lindy via iMessage" />
-</Frame>
-
 You can customize recurring tasks like briefings in your settings at [chat.lindy.ai](https://chat.lindy.ai). Daily briefings default to **7:00 AM**.
 
 ## Good to Know
@@ -104,6 +100,10 @@ If you're not receiving text messages, ensure your **Preferred Messaging Service
 </Frame>
 
 The setting defaults to **auto**, but you can override it to match your mobile device. If you're on Android and want to use RCS, open the **Google Messages** app, tap your profile picture, go to **Settings → RCS chats**, and turn on **"Turn on RCS chats"**.
+
+<Frame>
+  <img src="/lindy-brand-assets/daily-briefing.jpg" alt="Daily morning briefing from Lindy via iMessage" />
+</Frame>
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- Relocates the `daily-briefing.jpg` Frame from inside Recurring Tasks to just before **Next Steps** so it's the very last image on the page.
- The "You can customize recurring tasks..." sentence stays where it was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)