### PR TITLE
imessage-sms: move side-by-side image pair under Time & Priorities

### DIFF
--- a/features/imessage-sms.mdx
+++ b/features/imessage-sms.mdx
@@ -55,6 +55,11 @@ If you skipped the phone number step during signup, you can add it anytime: clic
 - **Prioritize your day**: "What should I focus on today?"
 - **React to changes**: "My 3pm cancelled, what should I do with that time?"
 
+<div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem', margin: '1.5rem 0' }}>
+  <img src="/lindy-brand-assets/imessage-organize-prioritize.png" alt="Organize & prioritize — Lindy: 'You're meeting with John from ACME, here's everything you need to know'" style={{ width: '100%', borderRadius: '16px' }} />
+  <img src="/lindy-brand-assets/imessage-send-reminders.png" alt="Send reminders — Lindy: 'Don't forget your pills'" style={{ width: '100%', borderRadius: '16px' }} />
+</div>
+
 ### Recurring Tasks
 
 - **Daily briefings**: "Send me a briefing every morning at 7am" (includes your calendar, important emails, weather, and news)
@@ -62,11 +67,6 @@ If you skipped the phone number step during signup, you can add it anytime: clic
 - **Standing instructions**: "Every time I finish a meeting, send the notes to Slack"
 - **Weekly recaps**: "Send me a summary of my week every Friday at 5pm"
 - **CRM updates after meetings**: "Update the CRM after every sales call"
-
-<div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem', margin: '1.5rem 0' }}>
-  <img src="/lindy-brand-assets/imessage-organize-prioritize.png" alt="Organize & prioritize — Lindy: 'You're meeting with John from ACME, here's everything you need to know'" style={{ width: '100%', borderRadius: '16px' }} />
-  <img src="/lindy-brand-assets/imessage-send-reminders.png" alt="Send reminders — Lindy: 'Don't forget your pills'" style={{ width: '100%', borderRadius: '16px' }} />
-</div>
 
 You can customize recurring tasks like briefings in your settings at [chat.lindy.ai](https://chat.lindy.ai). Daily briefings default to **7:00 AM**.
 


### PR DESCRIPTION
## Summary
- Moves the 2-column grid (Organize & prioritize + Send reminders) from below Recurring Tasks to below Time & Priorities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)