### PR TITLE
imessage-sms: daily-briefing image after Recurring Tasks (not page end)

### DIFF
--- a/features/imessage-sms.mdx
+++ b/features/imessage-sms.mdx
@@ -70,6 +70,10 @@ If you skipped the phone number step during signup, you can add it anytime: clic
 
 You can customize recurring tasks like briefings in your settings at [chat.lindy.ai](https://chat.lindy.ai). Daily briefings default to **7:00 AM**.
 
+<Frame>
+  <img src="/lindy-brand-assets/daily-briefing.jpg" alt="Daily morning briefing from Lindy via iMessage" />
+</Frame>
+
 ## Good to Know
 
 <AccordionGroup>
@@ -100,10 +104,6 @@ If you're not receiving text messages, ensure your **Preferred Messaging Service
 </Frame>
 
 The setting defaults to **auto**, but you can override it to match your mobile device. If you're on Android and want to use RCS, open the **Google Messages** app, tap your profile picture, go to **Settings → RCS chats**, and turn on **"Turn on RCS chats"**.
-
-<Frame>
-  <img src="/lindy-brand-assets/daily-briefing.jpg" alt="Daily morning briefing from Lindy via iMessage" />
-</Frame>
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- Reverts the previous placement of `daily-briefing.jpg` at the very end of the page; places it right after the Recurring Tasks "customize" sentence instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)