### PR TITLE
quickstart: turn the features table into a linkable CardGroup

### DIFF
--- a/start-here/quickstart.mdx
+++ b/start-here/quickstart.mdx
@@ -40,15 +40,25 @@ Lindy is the AI that runs your work life. Once you're set up, Lindy autonomously
 
 ## What Lindy Does Automatically
 
-Once you're set up, Lindy starts working right away. No configuration needed. One assistant replaces your entire work stack.
+Once you're set up, Lindy starts working right away. No configuration needed. One assistant replaces your entire work stack. Click any feature to dive deeper.
 
-| Feature | What Lindy Does |
-| --- | --- |
-| **Inbox Management** | Triages, prioritizes, drafts, and sends replies in your voice. Autonomously. |
-| **Meeting Prep** | Researches attendees and delivers a briefing before every meeting. |
-| **Meeting Notes** | Joins your meetings, records them, and generates interactive, searchable summaries. |
-| **Follow-ups** | Tracks action items and sends follow-up emails to attendees. |
-| **Daily Briefings** | Sends you a morning briefing with your calendar, important emails, and news. |
+<CardGroup cols={2}>
+  <Card title="Inbox Management" icon="inbox" href="/features/inbox-management/email-triage">
+    Triages, prioritizes, drafts, and sends replies in your voice — autonomously.
+  </Card>
+  <Card title="Meeting Prep" icon="clipboard-list" href="/features/meeting-assistant/meeting-prep">
+    Researches attendees and delivers a briefing before every meeting.
+  </Card>
+  <Card title="Meeting Notes" icon="microphone" href="/features/meeting-assistant/meeting-notes">
+    Joins your meetings, records them, and generates interactive, searchable summaries.
+  </Card>
+  <Card title="Follow-ups" icon="paper-plane" href="/features/meeting-assistant/follow-ups">
+    Tracks action items and sends follow-up emails to attendees.
+  </Card>
+  <Card title="Daily Briefings" icon="newspaper" href="/features/meeting-assistant/daily-brief">
+    Sends you a morning briefing with your calendar, important emails, and news.
+  </Card>
+</CardGroup>
 
 You can customize all of these in your settings at [chat.lindy.ai](https://chat.lindy.ai). Adjust what Lindy labels, how it drafts emails, when you get meeting prep, and more.
 


### PR DESCRIPTION
## Summary
- Replaces the **What Lindy Does Automatically** table on `/start-here/quickstart` with a 5-card `CardGroup` (2-column grid).
- Each card links to its full feature doc:
  - Inbox Management → email triage
  - Meeting Prep → meeting prep
  - Meeting Notes → meeting notes
  - Follow-ups → follow-ups
  - Daily Briefings → daily brief
- Uses the same icon each destination page uses for visual consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)