### PR TITLE
quickstart: purple feature cards + add Smart Scheduling

### DIFF
--- a/start-here/quickstart.mdx
+++ b/start-here/quickstart.mdx
@@ -42,23 +42,28 @@ Lindy is the AI that runs your work life. Once you're set up, Lindy autonomously
 
 Once you're set up, Lindy starts working right away. No configuration needed. One assistant replaces your entire work stack. Click any feature to dive deeper.
 
-<CardGroup cols={2}>
-  <Card title="Inbox Management" icon="inbox" href="/features/inbox-management/email-triage">
-    Triages, prioritizes, drafts, and sends replies in your voice — autonomously.
-  </Card>
-  <Card title="Meeting Prep" icon="clipboard-list" href="/features/meeting-assistant/meeting-prep">
-    Researches attendees and delivers a briefing before every meeting.
-  </Card>
-  <Card title="Meeting Notes" icon="microphone" href="/features/meeting-assistant/meeting-notes">
-    Joins your meetings, records them, and generates interactive, searchable summaries.
-  </Card>
-  <Card title="Follow-ups" icon="paper-plane" href="/features/meeting-assistant/follow-ups">
-    Tracks action items and sends follow-up emails to attendees.
-  </Card>
-  <Card title="Daily Briefings" icon="newspaper" href="/features/meeting-assistant/daily-brief">
-    Sends you a morning briefing with your calendar, important emails, and news.
-  </Card>
-</CardGroup>
+<div className="purple-feature-cards">
+  <CardGroup cols={2}>
+    <Card title="Inbox Management" icon="inbox" color="#7c3aed" href="/features/inbox-management/email-triage">
+      Triages, prioritizes, drafts, and sends replies in your voice — autonomously.
+    </Card>
+    <Card title="Meeting Prep" icon="clipboard-list" color="#7c3aed" href="/features/meeting-assistant/meeting-prep">
+      Researches attendees and delivers a briefing before every meeting.
+    </Card>
+    <Card title="Meeting Notes" icon="microphone" color="#7c3aed" href="/features/meeting-assistant/meeting-notes">
+      Joins your meetings, records them, and generates interactive, searchable summaries.
+    </Card>
+    <Card title="Follow-ups" icon="paper-plane" color="#7c3aed" href="/features/meeting-assistant/follow-ups">
+      Tracks action items and sends follow-up emails to attendees.
+    </Card>
+    <Card title="Smart Scheduling" icon="calendar" color="#7c3aed" href="/features/meeting-assistant/scheduling">
+      Finds times, sends invites, and locks in meetings — no more back-and-forth.
+    </Card>
+    <Card title="Daily Briefings" icon="newspaper" color="#7c3aed" href="/features/meeting-assistant/daily-brief">
+      Sends you a morning briefing with your calendar, important emails, and news.
+    </Card>
+  </CardGroup>
+</div>
 
 You can customize all of these in your settings at [chat.lindy.ai](https://chat.lindy.ai). Adjust what Lindy labels, how it drafts emails, when you get meeting prep, and more.
 

--- a/style.css
+++ b/style.css
@@ -1484,6 +1484,45 @@ video {
   color: #f1f5f9 !important;
 }
 
+/* ============== PURPLE FEATURE CARDS ============== */
+/* Used by the 'What Lindy Does Automatically' CardGroup on the quickstart page.
+   Wraps the CardGroup in a div.purple-feature-cards so we can override the default
+   yellow card hover/border accents with the Lindy purple (#7c3aed). */
+.purple-feature-cards .card {
+  border-color: rgba(124, 58, 237, 0.18) !important;
+  background-color: rgba(124, 58, 237, 0.03) !important;
+  transition: all 0.25s ease !important;
+}
+
+.purple-feature-cards .card:hover {
+  border-color: rgba(124, 58, 237, 0.45) !important;
+  background-color: rgba(124, 58, 237, 0.07) !important;
+  box-shadow: 0 8px 24px rgba(124, 58, 237, 0.18) !important;
+  transform: translateY(-4px);
+}
+
+.purple-feature-cards .card:hover h2,
+.purple-feature-cards .card:hover h3,
+.purple-feature-cards .card:hover h4,
+.purple-feature-cards .card:hover .card-title {
+  text-decoration: underline !important;
+  text-decoration-color: #7c3aed !important;
+  text-decoration-thickness: 1.5px !important;
+  text-underline-offset: 2px !important;
+}
+
+/* Dark-mode tuning so the purple still reads on the dark surface */
+.dark .purple-feature-cards .card {
+  background-color: rgba(124, 58, 237, 0.08) !important;
+  border-color: rgba(167, 139, 250, 0.35) !important;
+}
+
+.dark .purple-feature-cards .card:hover {
+  background-color: rgba(124, 58, 237, 0.15) !important;
+  border-color: rgba(167, 139, 250, 0.6) !important;
+  box-shadow: 0 8px 24px rgba(124, 58, 237, 0.25) !important;
+}
+
 /* ============== SIDEBAR GROUP SPACING ============== */
 /* Tighten the vertical gap between sidebar groups (Start Here, Texting & Tasks, etc.)
    Tailwind utility `mt-8` (2rem) on the group containers was creating very large gaps.


### PR DESCRIPTION
## Summary
- Adds **Smart Scheduling** as a 6th card in the **What Lindy Does Automatically** CardGroup (icon: calendar, links to `/features/meeting-assistant/scheduling`).
- Wraps the CardGroup in `<div className="purple-feature-cards">` and sets each card's icon `color="#7c3aed"`.
- Adds CSS overrides in `style.css` so this specific CardGroup gets purple-tinted borders, purple hover lift/shadow, and a purple underline on the title on hover (replacing the default yellow accents). Light + dark mode covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)