### PR TITLE
quickstart: desaturate purple feature cards

### DIFF
--- a/start-here/quickstart.mdx
+++ b/start-here/quickstart.mdx
@@ -44,22 +44,22 @@ Once you're set up, Lindy starts working right away. No configuration needed. On
 
 <div className="purple-feature-cards">
   <CardGroup cols={2}>
-    <Card title="Inbox Management" icon="inbox" color="#7c3aed" href="/features/inbox-management/email-triage">
+    <Card title="Inbox Management" icon="inbox" color="#a78bfa" href="/features/inbox-management/email-triage">
       Triages, prioritizes, drafts, and sends replies in your voice — autonomously.
     </Card>
-    <Card title="Meeting Prep" icon="clipboard-list" color="#7c3aed" href="/features/meeting-assistant/meeting-prep">
+    <Card title="Meeting Prep" icon="clipboard-list" color="#a78bfa" href="/features/meeting-assistant/meeting-prep">
       Researches attendees and delivers a briefing before every meeting.
     </Card>
-    <Card title="Meeting Notes" icon="microphone" color="#7c3aed" href="/features/meeting-assistant/meeting-notes">
+    <Card title="Meeting Notes" icon="microphone" color="#a78bfa" href="/features/meeting-assistant/meeting-notes">
       Joins your meetings, records them, and generates interactive, searchable summaries.
     </Card>
-    <Card title="Follow-ups" icon="paper-plane" color="#7c3aed" href="/features/meeting-assistant/follow-ups">
+    <Card title="Follow-ups" icon="paper-plane" color="#a78bfa" href="/features/meeting-assistant/follow-ups">
       Tracks action items and sends follow-up emails to attendees.
     </Card>
-    <Card title="Smart Scheduling" icon="calendar" color="#7c3aed" href="/features/meeting-assistant/scheduling">
+    <Card title="Smart Scheduling" icon="calendar" color="#a78bfa" href="/features/meeting-assistant/scheduling">
       Finds times, sends invites, and locks in meetings — no more back-and-forth.
     </Card>
-    <Card title="Daily Briefings" icon="newspaper" color="#7c3aed" href="/features/meeting-assistant/daily-brief">
+    <Card title="Daily Briefings" icon="newspaper" color="#a78bfa" href="/features/meeting-assistant/daily-brief">
       Sends you a morning briefing with your calendar, important emails, and news.
     </Card>
   </CardGroup>

--- a/style.css
+++ b/style.css
@@ -1489,16 +1489,16 @@ video {
    Wraps the CardGroup in a div.purple-feature-cards so we can override the default
    yellow card hover/border accents with the Lindy purple (#7c3aed). */
 .purple-feature-cards .card {
-  border-color: rgba(124, 58, 237, 0.18) !important;
-  background-color: rgba(124, 58, 237, 0.03) !important;
+  border-color: rgba(124, 58, 237, 0.1) !important;
+  background-color: transparent !important;
   transition: all 0.25s ease !important;
 }
 
 .purple-feature-cards .card:hover {
-  border-color: rgba(124, 58, 237, 0.45) !important;
-  background-color: rgba(124, 58, 237, 0.07) !important;
-  box-shadow: 0 8px 24px rgba(124, 58, 237, 0.18) !important;
-  transform: translateY(-4px);
+  border-color: rgba(124, 58, 237, 0.22) !important;
+  background-color: rgba(124, 58, 237, 0.025) !important;
+  box-shadow: 0 6px 18px rgba(124, 58, 237, 0.1) !important;
+  transform: translateY(-3px);
 }
 
 .purple-feature-cards .card:hover h2,
@@ -1506,21 +1506,21 @@ video {
 .purple-feature-cards .card:hover h4,
 .purple-feature-cards .card:hover .card-title {
   text-decoration: underline !important;
-  text-decoration-color: #7c3aed !important;
+  text-decoration-color: #a78bfa !important;
   text-decoration-thickness: 1.5px !important;
   text-underline-offset: 2px !important;
 }
 
 /* Dark-mode tuning so the purple still reads on the dark surface */
 .dark .purple-feature-cards .card {
-  background-color: rgba(124, 58, 237, 0.08) !important;
-  border-color: rgba(167, 139, 250, 0.35) !important;
+  background-color: transparent !important;
+  border-color: rgba(167, 139, 250, 0.22) !important;
 }
 
 .dark .purple-feature-cards .card:hover {
-  background-color: rgba(124, 58, 237, 0.15) !important;
-  border-color: rgba(167, 139, 250, 0.6) !important;
-  box-shadow: 0 8px 24px rgba(124, 58, 237, 0.25) !important;
+  background-color: rgba(167, 139, 250, 0.06) !important;
+  border-color: rgba(167, 139, 250, 0.4) !important;
+  box-shadow: 0 6px 18px rgba(124, 58, 237, 0.18) !important;
 }
 
 /* ============== SIDEBAR GROUP SPACING ============== */


### PR DESCRIPTION
## Summary
- Drops the icon color from `#7c3aed` (violet-600) to `#a78bfa` (violet-400) — same hue, less saturated.
- Reduces card border tint, drops the resting background tint to transparent, and softens the hover shadow.
- Same dial-down applied to dark-mode variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)