### PR TITLE
quickstart: horizontal action-card rectangles

### DIFF
--- a/start-here/quickstart.mdx
+++ b/start-here/quickstart.mdx
@@ -43,23 +43,23 @@ Lindy is the AI that runs your work life. Once you're set up, Lindy autonomously
 Once you're set up, Lindy starts working right away. No configuration needed. One assistant replaces your entire work stack. Click any feature to dive deeper.
 
 <div className="purple-feature-cards">
-  <CardGroup cols={2}>
-    <Card title="Inbox Management" icon="inbox" color="#a78bfa" href="/features/inbox-management/email-triage">
+  <CardGroup cols={1}>
+    <Card title="Inbox Management" icon="inbox" color="#a78bfa" href="/features/inbox-management/email-triage" horizontal>
       Triages, prioritizes, drafts, and sends replies in your voice — autonomously.
     </Card>
-    <Card title="Meeting Prep" icon="clipboard-list" color="#a78bfa" href="/features/meeting-assistant/meeting-prep">
+    <Card title="Meeting Prep" icon="clipboard-list" color="#a78bfa" href="/features/meeting-assistant/meeting-prep" horizontal>
       Researches attendees and delivers a briefing before every meeting.
     </Card>
-    <Card title="Meeting Notes" icon="microphone" color="#a78bfa" href="/features/meeting-assistant/meeting-notes">
+    <Card title="Meeting Notes" icon="microphone" color="#a78bfa" href="/features/meeting-assistant/meeting-notes" horizontal>
       Joins your meetings, records them, and generates interactive, searchable summaries.
     </Card>
-    <Card title="Follow-ups" icon="paper-plane" color="#a78bfa" href="/features/meeting-assistant/follow-ups">
+    <Card title="Follow-ups" icon="paper-plane" color="#a78bfa" href="/features/meeting-assistant/follow-ups" horizontal>
       Tracks action items and sends follow-up emails to attendees.
     </Card>
-    <Card title="Smart Scheduling" icon="calendar" color="#a78bfa" href="/features/meeting-assistant/scheduling">
+    <Card title="Smart Scheduling" icon="calendar" color="#a78bfa" href="/features/meeting-assistant/scheduling" horizontal>
       Finds times, sends invites, and locks in meetings — no more back-and-forth.
     </Card>
-    <Card title="Daily Briefings" icon="newspaper" color="#a78bfa" href="/features/meeting-assistant/daily-brief">
+    <Card title="Daily Briefings" icon="newspaper" color="#a78bfa" href="/features/meeting-assistant/daily-brief" horizontal>
       Sends you a morning briefing with your calendar, important emails, and news.
     </Card>
   </CardGroup>

--- a/style.css
+++ b/style.css
@@ -1491,14 +1491,16 @@ video {
 .purple-feature-cards .card {
   border-color: rgba(124, 58, 237, 0.1) !important;
   background-color: transparent !important;
-  transition: all 0.25s ease !important;
+  transition: all 0.2s ease !important;
+  padding: 1rem 1.25rem !important;
+  border-radius: 12px !important;
 }
 
 .purple-feature-cards .card:hover {
   border-color: rgba(124, 58, 237, 0.22) !important;
   background-color: rgba(124, 58, 237, 0.025) !important;
-  box-shadow: 0 6px 18px rgba(124, 58, 237, 0.1) !important;
-  transform: translateY(-3px);
+  box-shadow: 0 3px 12px rgba(124, 58, 237, 0.08) !important;
+  transform: none !important;
 }
 
 .purple-feature-cards .card:hover h2,


### PR DESCRIPTION
## Summary
- Replaces the 2-column grid of large square cards with a single-column **CardGroup** of horizontal Cards (icon on left, title + description on right, full row width). Reads like a clickable table.
- Tighter row padding (`1rem 1.25rem`) and `12px` rounded corners.
- Drops the hover lift transform; just a subtle border + soft shadow on hover so it still feels interactive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)