### PR TITLE
quickstart: feature cards in 2x3 grid (still horizontal)

### DIFF
--- a/start-here/quickstart.mdx
+++ b/start-here/quickstart.mdx
@@ -43,7 +43,7 @@ Lindy is the AI that runs your work life. Once you're set up, Lindy autonomously
 Once you're set up, Lindy starts working right away. No configuration needed. One assistant replaces your entire work stack. Click any feature to dive deeper.
 
 <div className="purple-feature-cards">
-  <CardGroup cols={1}>
+  <CardGroup cols={2}>
     <Card title="Inbox Management" icon="inbox" color="#a78bfa" href="/features/inbox-management/email-triage" horizontal>
       Triages, prioritizes, drafts, and sends replies in your voice — autonomously.
     </Card>


### PR DESCRIPTION
## Summary
- Switches the feature CardGroup from `cols={1}` (single-column full-width pills) to `cols={2}` so the six horizontal Cards arrange as 2 columns × 3 rows.
- Keeps the horizontal Card layout + tightened padding from the previous PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)