### PR TITLE
quickstart: revert purple feature cards back to brand gold

### DIFF
--- a/start-here/quickstart.mdx
+++ b/start-here/quickstart.mdx
@@ -42,28 +42,26 @@ Lindy is the AI that runs your work life. Once you're set up, Lindy autonomously
 
 Once you're set up, Lindy starts working right away. No configuration needed. One assistant replaces your entire work stack. Click any feature to dive deeper.
 
-<div className="purple-feature-cards">
-  <CardGroup cols={2}>
-    <Card title="Inbox Management" icon="inbox" color="#a78bfa" href="/features/inbox-management/email-triage" horizontal>
-      Triages, prioritizes, drafts, and sends replies in your voice — autonomously.
-    </Card>
-    <Card title="Meeting Prep" icon="clipboard-list" color="#a78bfa" href="/features/meeting-assistant/meeting-prep" horizontal>
-      Researches attendees and delivers a briefing before every meeting.
-    </Card>
-    <Card title="Meeting Notes" icon="microphone" color="#a78bfa" href="/features/meeting-assistant/meeting-notes" horizontal>
-      Joins your meetings, records them, and generates interactive, searchable summaries.
-    </Card>
-    <Card title="Follow-ups" icon="paper-plane" color="#a78bfa" href="/features/meeting-assistant/follow-ups" horizontal>
-      Tracks action items and sends follow-up emails to attendees.
-    </Card>
-    <Card title="Smart Scheduling" icon="calendar" color="#a78bfa" href="/features/meeting-assistant/scheduling" horizontal>
-      Finds times, sends invites, and locks in meetings — no more back-and-forth.
-    </Card>
-    <Card title="Daily Briefings" icon="newspaper" color="#a78bfa" href="/features/meeting-assistant/daily-brief" horizontal>
-      Sends you a morning briefing with your calendar, important emails, and news.
-    </Card>
-  </CardGroup>
-</div>
+<CardGroup cols={2}>
+  <Card title="Inbox Management" icon="inbox" href="/features/inbox-management/email-triage" horizontal>
+    Triages, prioritizes, drafts, and sends replies in your voice — autonomously.
+  </Card>
+  <Card title="Meeting Prep" icon="clipboard-list" href="/features/meeting-assistant/meeting-prep" horizontal>
+    Researches attendees and delivers a briefing before every meeting.
+  </Card>
+  <Card title="Meeting Notes" icon="microphone" href="/features/meeting-assistant/meeting-notes" horizontal>
+    Joins your meetings, records them, and generates interactive, searchable summaries.
+  </Card>
+  <Card title="Follow-ups" icon="paper-plane" href="/features/meeting-assistant/follow-ups" horizontal>
+    Tracks action items and sends follow-up emails to attendees.
+  </Card>
+  <Card title="Smart Scheduling" icon="calendar" href="/features/meeting-assistant/scheduling" horizontal>
+    Finds times, sends invites, and locks in meetings — no more back-and-forth.
+  </Card>
+  <Card title="Daily Briefings" icon="newspaper" href="/features/meeting-assistant/daily-brief" horizontal>
+    Sends you a morning briefing with your calendar, important emails, and news.
+  </Card>
+</CardGroup>
 
 You can customize all of these in your settings at [chat.lindy.ai](https://chat.lindy.ai). Adjust what Lindy labels, how it drafts emails, when you get meeting prep, and more.
 

--- a/style.css
+++ b/style.css
@@ -1484,46 +1484,6 @@ video {
   color: #f1f5f9 !important;
 }
 
-/* ============== PURPLE FEATURE CARDS ============== */
-/* Used by the 'What Lindy Does Automatically' CardGroup on the quickstart page.
-   Wraps the CardGroup in a div.purple-feature-cards so we can override the default
-   yellow card hover/border accents with the Lindy purple (#7c3aed). */
-.purple-feature-cards .card {
-  border-color: rgba(124, 58, 237, 0.1) !important;
-  background-color: transparent !important;
-  transition: all 0.2s ease !important;
-  padding: 1rem 1.25rem !important;
-  border-radius: 12px !important;
-}
-
-.purple-feature-cards .card:hover {
-  border-color: rgba(124, 58, 237, 0.22) !important;
-  background-color: rgba(124, 58, 237, 0.025) !important;
-  box-shadow: 0 3px 12px rgba(124, 58, 237, 0.08) !important;
-  transform: none !important;
-}
-
-.purple-feature-cards .card:hover h2,
-.purple-feature-cards .card:hover h3,
-.purple-feature-cards .card:hover h4,
-.purple-feature-cards .card:hover .card-title {
-  text-decoration: underline !important;
-  text-decoration-color: #a78bfa !important;
-  text-decoration-thickness: 1.5px !important;
-  text-underline-offset: 2px !important;
-}
-
-/* Dark-mode tuning so the purple still reads on the dark surface */
-.dark .purple-feature-cards .card {
-  background-color: transparent !important;
-  border-color: rgba(167, 139, 250, 0.22) !important;
-}
-
-.dark .purple-feature-cards .card:hover {
-  background-color: rgba(167, 139, 250, 0.06) !important;
-  border-color: rgba(167, 139, 250, 0.4) !important;
-  box-shadow: 0 6px 18px rgba(124, 58, 237, 0.18) !important;
-}
 
 /* ============== SIDEBAR GROUP SPACING ============== */
 /* Tighten the vertical gap between sidebar groups (Start Here, Texting & Tasks, etc.)


### PR DESCRIPTION
## Summary
- Removes the purple icon color and the `.purple-feature-cards` div wrapper.
- Deletes the purple CSS overrides in `style.css`.
- The 2-col × 3-row horizontal Card layout stays — now it just uses Lindy's default brand styling (gold accent, standard card hover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)