### PR TITLE
best-practices: bordered info-card containers (replace Tabs)

### DIFF
--- a/start-here/best-practices.mdx
+++ b/start-here/best-practices.mdx
@@ -40,36 +40,48 @@ The more Lindy knows about you, the better she can help. Open iMessage, hit reco
 
 **On desktop?** Open iMessage on your phone and go through as many sections as you want.
 
-<Tabs>
-  <Tab title="Start Here">
-    Four things Lindy needs on day one:
+<div className="info-card">
 
-    1. Your name, role, and company
-    2. What you spend most of your day doing
-    3. Things eating too much of your time
-    4. Your work hours and time zone
+### Start Here
 
-    Everything below is optional. Share it whenever, in any order.
-  </Tab>
-  <Tab title="Daily Basics">
-    **Calendar:** Protected blocks, preferred meeting length, buffer time, ideal meeting windows.
+Four things Lindy needs on day one:
 
-    **Meetings:** Which meetings Lindy should join or skip. Post-meeting tasks that eat your time (follow-ups, CRM updates, Slack notes).
+1. Your name, role, and company
+2. What you spend most of your day doing
+3. Things eating too much of your time
+4. Your work hours and time zone
 
-    **Email:** Most important contacts, emails to alert you about, emails to auto-archive.
+Everything below is optional. Share it whenever, in any order.
 
-    **Briefings:** Text or voice recap, time to receive them, content to include (news, quotes, etc.), whether you want an end-of-day brief.
-  </Tab>
-  <Tab title="All About You">
-    **Priorities:** Top priorities, projects to protect time for, KPIs you're tracking.
+</div>
 
-    **Personal:** Partner/kids/family names, recurring obligations, favorite restaurants, dietary restrictions, go-to gift ideas.
+<div className="info-card">
 
-    **Working style:** What a good day feels like, how direct you want feedback, routines Lindy should support, times you do your best thinking.
+### Daily Basics
 
-    **Tools:** Your productivity stack, where tasks live today, how aggressive reminders should be, recurring annual reminders.
-  </Tab>
-</Tabs>
+**Calendar:** Protected blocks, preferred meeting length, buffer time, ideal meeting windows.
+
+**Meetings:** Which meetings Lindy should join or skip. Post-meeting tasks that eat your time (follow-ups, CRM updates, Slack notes).
+
+**Email:** Most important contacts, emails to alert you about, emails to auto-archive.
+
+**Briefings:** Text or voice recap, time to receive them, content to include (news, quotes, etc.), whether you want an end-of-day brief.
+
+</div>
+
+<div className="info-card">
+
+### All About You
+
+**Priorities:** Top priorities, projects to protect time for, KPIs you're tracking.
+
+**Personal:** Partner/kids/family names, recurring obligations, favorite restaurants, dietary restrictions, go-to gift ideas.
+
+**Working style:** What a good day feels like, how direct you want feedback, routines Lindy should support, times you do your best thinking.
+
+**Tools:** Your productivity stack, where tasks live today, how aggressive reminders should be, recurring annual reminders.
+
+</div>
 
 ## Give Lots of Feedback
 

--- a/style.css
+++ b/style.css
@@ -1484,6 +1484,36 @@ video {
   color: #f1f5f9 !important;
 }
 
+/* ============== INFO CARDS ============== */
+/* Bordered card-style containers for long-form sub-sections that would otherwise
+   blend into the rest of the page (Start Here, Daily Basics, All About You on
+   the best-practices page). */
+.info-card {
+  border: 1px solid var(--color-border);
+  border-left: 4px solid var(--color-primary);
+  border-radius: 12px;
+  padding: 1.25rem 1.75rem;
+  margin: 1.5rem 0;
+  background-color: rgba(240, 195, 65, 0.04);
+}
+
+.info-card > h3:first-child,
+.info-card > h2:first-child,
+.info-card > :first-child {
+  margin-top: 0 !important;
+}
+
+.info-card > :last-child {
+  margin-bottom: 0 !important;
+}
+
+/* Dark-mode tuning */
+.dark .info-card {
+  border-color: rgba(245, 225, 152, 0.18);
+  border-left-color: #F5E198;
+  background-color: rgba(245, 225, 152, 0.05);
+}
+
 
 /* ============== SIDEBAR GROUP SPACING ============== */
 /* Tighten the vertical gap between sidebar groups (Start Here, Texting & Tasks, etc.)


### PR DESCRIPTION
## Summary
- Drops the `<Tabs>` wrapper from PR #247 — it hid 2 of 3 sub-sections at any given time.
- Wraps each of Start Here, Daily Basics, and All About You in a `<div className="info-card">` container.
- Adds `.info-card` to `style.css`: rounded corners, soft border, gold left accent (`--color-primary`), light tint background. Dark-mode variant tuned with the lighter brand yellow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)