### PR TITLE
best-practices: make info cards BIG

### DIFF
--- a/style.css
+++ b/style.css
@@ -1490,11 +1490,12 @@ video {
    the best-practices page). */
 .info-card {
   border: 1px solid var(--color-border);
-  border-left: 4px solid var(--color-primary);
-  border-radius: 12px;
-  padding: 1.25rem 1.75rem;
-  margin: 1.5rem 0;
-  background-color: rgba(240, 195, 65, 0.04);
+  border-left: 6px solid var(--color-primary);
+  border-radius: 16px;
+  padding: 2.5rem 2.75rem;
+  margin: 2.5rem 0;
+  background-color: rgba(240, 195, 65, 0.06);
+  box-shadow: 0 4px 16px rgba(240, 195, 65, 0.1);
 }
 
 .info-card > h3:first-child,
@@ -1507,11 +1508,18 @@ video {
   margin-bottom: 0 !important;
 }
 
+/* Make the heading inside an info-card bigger and tighter to the content below */
+.info-card h3 {
+  font-size: 2rem !important;
+  margin-bottom: 1.25rem !important;
+}
+
 /* Dark-mode tuning */
 .dark .info-card {
-  border-color: rgba(245, 225, 152, 0.18);
+  border-color: rgba(245, 225, 152, 0.2);
   border-left-color: #F5E198;
-  background-color: rgba(245, 225, 152, 0.05);
+  background-color: rgba(245, 225, 152, 0.07);
+  box-shadow: 0 4px 16px rgba(245, 225, 152, 0.08);
 }
 
 


### PR DESCRIPTION
## Summary
- Beefs up the `.info-card` styling on `/start-here/best-practices`: more padding, more margin between cards, thicker gold left accent, larger corner radius, tinted background, soft gold drop shadow.
- Bumps the H3 heading inside each card to 2rem so the title pops.
- Dark-mode variants tuned to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)