### PR TITLE
best-practices: spacing fix inside info cards

### DIFF
--- a/style.css
+++ b/style.css
@@ -1514,6 +1514,30 @@ video {
   margin-bottom: 1.25rem !important;
 }
 
+/* Give paragraphs inside an info-card real breathing room */
+.info-card p {
+  margin-bottom: 1.5rem !important;
+}
+
+.info-card p:last-child {
+  margin-bottom: 0 !important;
+}
+
+/* Tighten the gap inside the same paragraph after a block-display strong label */
+.info-card p strong,
+.info-card p b {
+  margin-top: 0 !important;
+}
+
+/* List items inside info-cards: a bit more spacing too */
+.info-card li {
+  margin-bottom: 0.75rem;
+}
+
+.info-card li:last-child {
+  margin-bottom: 0;
+}
+
 /* Dark-mode tuning */
 .dark .info-card {
   border-color: rgba(245, 225, 152, 0.2);


### PR DESCRIPTION
## Summary
Adds CSS so the `**Label:** description` paragraphs and numbered list items inside `.info-card` aren't cramped:
- Paragraph bottom margin → 1.5rem (last child resets to 0)
- List item bottom margin → 0.75rem
- Clears the leftover top-margin that the global `p strong` rule adds inside info-card paragraphs

🤖 Generated with [Claude Code](https://claude.com/claude-code)