### PR TITLE
best-practices: pair Voice Memos + Give Info at the bottom of the page

### DIFF
--- a/start-here/best-practices.mdx
+++ b/start-here/best-practices.mdx
@@ -28,64 +28,12 @@ Configure Lindy's behavior through the web interface, or simply ask her in plain
   <img src="/lindy-brand-assets/tweak-settings-imessage.png" alt="Texting Lindy 'auto-archive all my uber emails' and getting back 'done. i'll file those automatically from now on. you can tweak any of this in settings too'" />
 </Frame>
 
-## Give Lindy Lots of Information
-
-The more Lindy knows about you, the better she can help. Open iMessage, hit record, and brief her like a new hire — five minutes covers a lot.
-
-<Frame>
-  <img src="/lindy-brand-assets/give-info-imessage.png" alt="Texting Lindy 'couple things to know about me — top priority this quarter is the acme deal, and loop sarah in on anything finance related' and getting back 'got it, saved both. i'll keep these in mind going forward'" />
-</Frame>
-
-**On mobile?** Just cover the basics below and send more voice notes over the next few days.
-
-**On desktop?** Open iMessage on your phone and go through as many sections as you want.
-
-<div className="info-card">
-  <h3>Start Here</h3>
-  <p>Four things Lindy needs on day one:</p>
-  <ol>
-    <li>Your name, role, and company</li>
-    <li>What you spend most of your day doing</li>
-    <li>Things eating too much of your time</li>
-    <li>Your work hours and time zone</li>
-  </ol>
-  <p>Everything below is optional. Share it whenever, in any order.</p>
-</div>
-
-<div className="info-card">
-  <h3>Daily Basics</h3>
-  <ul>
-    <li><strong>Calendar:</strong> Protected blocks, preferred meeting length, buffer time, ideal meeting windows.</li>
-    <li><strong>Meetings:</strong> Which meetings Lindy should join or skip. Post-meeting tasks that eat your time (follow-ups, CRM updates, Slack notes).</li>
-    <li><strong>Email:</strong> Most important contacts, emails to alert you about, emails to auto-archive.</li>
-    <li><strong>Briefings:</strong> Text or voice recap, time to receive them, content to include (news, quotes, etc.), whether you want an end-of-day brief.</li>
-  </ul>
-</div>
-
-<div className="info-card">
-  <h3>All About You</h3>
-  <ul>
-    <li><strong>Priorities:</strong> Top priorities, projects to protect time for, KPIs you're tracking.</li>
-    <li><strong>Personal:</strong> Partner/kids/family names, recurring obligations, favorite restaurants, dietary restrictions, go-to gift ideas.</li>
-    <li><strong>Working style:</strong> What a good day feels like, how direct you want feedback, routines Lindy should support, times you do your best thinking.</li>
-    <li><strong>Tools:</strong> Your productivity stack, where tasks live today, how aggressive reminders should be, recurring annual reminders.</li>
-  </ul>
-</div>
-
 ## Give Lots of Feedback
 
 Lindy gets better the more you use her. If she gets anything wrong, just share quick feedback — she'll learn from it.
 
 <Frame>
   <img src="/lindy-brand-assets/feedback-imessage.png" alt="Lindy says 'heads up, new invoice from deel' and user replies 'no need to flag invoices — finance has those covered.' Lindy: 'got it, i won't flag those going forward'" />
-</Frame>
-
-## Use Voice Memos
-
-The easiest way to brain dump on Lindy. Hit the voice button in iMessage and talk like you're handing off to a human assistant.
-
-<Frame>
-  <img src="/lindy-brand-assets/voice-memo-imessage.png" alt="Voice memo iMessage to Lindy ('Okay I'm out most of next week, here's what needs to happen...') with Lindy replying 'got all that. added 5 to-dos and i'll cover your inbox while you're out'" />
 </Frame>
 
 ## Text Me Like You'd Text a Human Assistant
@@ -165,6 +113,60 @@ Tell Lindy the outcome — she'll handle the back-and-forth.
     - "What's coming up this week I might forget?"
   </Accordion>
 </AccordionGroup>
+
+## Use Voice Memos
+
+The easiest way to brain dump on Lindy. Hit the voice button in iMessage and talk like you're handing off to a human assistant.
+
+<Frame>
+  <img src="/lindy-brand-assets/voice-memo-imessage.png" alt="Voice memo iMessage to Lindy ('Okay I'm out most of next week, here's what needs to happen...') with Lindy replying 'got all that. added 5 to-dos and i'll cover your inbox while you're out'" />
+</Frame>
+
+It's the fastest way to do what comes next — dump a brain-load of info Lindy needs about you.
+
+## Give Lindy Lots of Information (Over Voice Memo)
+
+The more Lindy knows about you, the better she can help. Open iMessage, **hit the voice button**, and brief her like a new hire — five minutes covers a lot.
+
+<Frame>
+  <img src="/lindy-brand-assets/give-info-imessage.png" alt="Texting Lindy 'couple things to know about me — top priority this quarter is the acme deal, and loop sarah in on anything finance related' and getting back 'got it, saved both. i'll keep these in mind going forward'" />
+</Frame>
+
+**On mobile?** Just cover the basics below and send more voice notes over the next few days.
+
+**On desktop?** Open iMessage on your phone and go through as many sections as you want.
+
+<div className="info-card">
+  <h3>Start Here</h3>
+  <p>Four things Lindy needs on day one:</p>
+  <ol>
+    <li>Your name, role, and company</li>
+    <li>What you spend most of your day doing</li>
+    <li>Things eating too much of your time</li>
+    <li>Your work hours and time zone</li>
+  </ol>
+  <p>Everything below is optional. Share it whenever, in any order.</p>
+</div>
+
+<div className="info-card">
+  <h3>Daily Basics</h3>
+  <ul>
+    <li><strong>Calendar:</strong> Protected blocks, preferred meeting length, buffer time, ideal meeting windows.</li>
+    <li><strong>Meetings:</strong> Which meetings Lindy should join or skip. Post-meeting tasks that eat your time (follow-ups, CRM updates, Slack notes).</li>
+    <li><strong>Email:</strong> Most important contacts, emails to alert you about, emails to auto-archive.</li>
+    <li><strong>Briefings:</strong> Text or voice recap, time to receive them, content to include (news, quotes, etc.), whether you want an end-of-day brief.</li>
+  </ul>
+</div>
+
+<div className="info-card">
+  <h3>All About You</h3>
+  <ul>
+    <li><strong>Priorities:</strong> Top priorities, projects to protect time for, KPIs you're tracking.</li>
+    <li><strong>Personal:</strong> Partner/kids/family names, recurring obligations, favorite restaurants, dietary restrictions, go-to gift ideas.</li>
+    <li><strong>Working style:</strong> What a good day feels like, how direct you want feedback, routines Lindy should support, times you do your best thinking.</li>
+    <li><strong>Tools:</strong> Your productivity stack, where tasks live today, how aggressive reminders should be, recurring annual reminders.</li>
+  </ul>
+</div>
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
Reorders `/start-here/best-practices` so the brain-dump action lives at the end:

1. **Use Voice Memos** — explains the medium, ends with "It's the fastest way to do what comes next — dump a brain-load of info Lindy needs about you."
2. **Give Lindy Lots of Information (Over Voice Memo)** — renamed heading + updated intro ("hit the voice button" instead of "hit record") so it's unmistakably the action you do *via* voice memos. The three info-cards (Start Here / Daily Basics / All About You) follow.

Both sections were previously mid-page and disconnected from each other. Now they read as one continuous "go brain-dump everything to Lindy" closer right before Next Steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)