### PR TITLE
ad-hoc-tasks: add Ask Lindy To... accordion + Send/Organize image grid

### DIFF
--- a/features/ad-hoc-tasks.mdx
+++ b/features/ad-hoc-tasks.mdx
@@ -43,6 +43,67 @@ Lindy remembers everything from your past emails and meetings. Ask questions any
 - **Surface action items**: "What were the action items from last week's team sync?"
 - **Track commitments**: "What did I promise [name] I'd send them?"
 
+## Ask Lindy To...
+
+<AccordionGroup>
+  <Accordion title="Calendar and scheduling">
+    - "Block 2 hours for deep work this week"
+    - "Move my 3pm to Thursday"
+    - "What does my week look like?"
+    - "Schedule a 30-min call with \[name\] next week"
+    - "Cancel my meeting with \[name\] tomorrow"
+  </Accordion>
+
+  <Accordion title="Email">
+    - "Draft a reply to that last email from \[name\]"
+    - "Follow up with \[name\] if they don't reply by Wednesday"
+    - "What emails need my attention right now?"
+    - "Draft a cold intro to \[name\] at \[company\]"
+  </Accordion>
+
+  <Accordion title="Meetings">
+    - "Prep me for my next call"
+    - "Research \[person/company\] before my 2pm"
+    - "Send \[name\] a recap with next steps"
+    - "What action items came out of today's meetings?"
+  </Accordion>
+
+  <Accordion title="Reminders">
+    - "Remind me to follow up with \[name\] on Thursday"
+    - "Remind me every Monday to review my pipeline"
+    - "Check in with me at 5pm about whether I finished the proposal"
+  </Accordion>
+
+  <Accordion title="Research">
+    - "Summarize this" \+ paste a link
+    - "What's \[company\] been up to lately?"
+    - "Find a restaurant near \[location\] for a client dinner"
+  </Accordion>
+
+  <Accordion title="Daily habits">
+    - "Send me my wins at 8pm every day"
+    - "Text me my top 3 priorities every morning at 7am"
+    - "Recap my day at 9pm as a voice note"
+  </Accordion>
+
+  <Accordion title="Tasks">
+    - "Add \[task\] to my to-do list"
+    - "What's still on my list from this week?"
+    - "What did I commit to after yesterday's meetings?"
+  </Accordion>
+
+  <Accordion title="Personal">
+    - "Find a gift under \$100 for \[name\]"
+    - "Book a reservation for 2 at \[restaurant\] Saturday night"
+    - "What's coming up this week I might forget?"
+  </Accordion>
+</AccordionGroup>
+
+<div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem', margin: '1.5rem 0' }}>
+  <img src="/lindy-brand-assets/imessage-send-reminders.png" alt="Send reminders — Lindy: 'Don't forget your pills'" style={{ width: '100%', borderRadius: '16px' }} />
+  <img src="/lindy-brand-assets/imessage-organize-prioritize.png" alt="Organize & prioritize — Lindy: 'You're meeting with John from ACME, here's everything you need to know'" style={{ width: '100%', borderRadius: '16px' }} />
+</div>
+
 ## Next Steps
 
 <CardGroup cols={2}>


### PR DESCRIPTION
## Summary
- Adds the **Ask Lindy To...** AccordionGroup (Calendar, Email, Meetings, Reminders, Research, Daily habits, Tasks, Personal) to `/features/ad-hoc-tasks` — same catalog already on best-practices.
- Adds a 2-column image grid at the bottom (before Next Steps) using the existing `imessage-send-reminders.png` + `imessage-organize-prioritize.png` brand assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)