### PR TITLE
homepage: reposition as "ultimate AI executive assistant"

### DIFF
--- a/index.mdx
+++ b/index.mdx
@@ -5,9 +5,9 @@ icon: 'sparkles'
 sidebarTitle: 'What is Lindy?'
 ---
 
-## The AI That Runs Your Work Life
+## The ultimate AI executive assistant
 
-Lindy is a personalized AI assistant that runs your work life autonomously, giving you 10+ hours back every week. Set up in 2 minutes. No new tools to learn.
+Lindy is an AI executive assistant that runs your work life autonomously, giving you 10+ hours back every week. Set up in two minutes. No new tools to learn.
 
 <Frame>
   <a href="https://chat.lindy.ai/signup" target="_blank" rel="noopener">
@@ -18,17 +18,17 @@ Lindy is a personalized AI assistant that runs your work life autonomously, givi
 ## What Lindy Does for You
 
 <CardGroup cols={2}>
-  <Card title="Inbox Management" icon="inbox" href="/features/inbox-management/email-triage">
-    Triages, prioritizes, drafts, and sends replies in your voice. Your inbox is handled before you open it.
+  <Card title="Email Triage" icon="inbox" href="/features/inbox-management/email-triage">
+    Sorts, labels, and prioritizes your inbox so you start every day in control.
   </Card>
-  <Card title="Meeting Assistant" icon="video" href="/features/meeting-assistant/meeting-prep">
-    Preps you before meetings, takes notes, and sends follow-ups with action items.
+  <Card title="Email Drafting" icon="pen" href="/features/inbox-management/email-drafting">
+    AI-drafted replies land in your drafts folder, ready to review and send.
   </Card>
-  <Card title="iMessage & SMS" icon="message" href="/features/imessage-sms">
-    Text Lindy like a friend. Delegate work from anywhere.
+  <Card title="Meeting Prep" icon="clipboard-list" href="/features/meeting-assistant/meeting-prep">
+    Pre-meeting briefings with attendee research, past context, and agenda.
   </Card>
-  <Card title="Ad Hoc Tasks" icon="wand-magic-sparkles" href="/features/ad-hoc-tasks">
-    Research, look things up, and get things done on demand.
+  <Card title="Smart Scheduling" icon="calendar" href="/features/meeting-assistant/scheduling">
+    Finds times, sends invites, and locks in meetings — no more back-and-forth.
   </Card>
 </CardGroup>
 


### PR DESCRIPTION
## What changed

Updates the homepage (`index.mdx`) hero and use-case cards.

**Hero**
- Heading: "The AI That Runs Your Work Life" → **"The ultimate AI executive assistant"**
- Subhead reworded to lead with "AI executive assistant"; "2 minutes" → "two minutes"

**What Lindy Does for You cards** — replaced the old four (Inbox Management, Meeting Assistant, iMessage & SMS, Ad Hoc Tasks) with four use cases aligned to the actual feature docs:

| Card | Links to |
|------|----------|
| Email Triage | `/features/inbox-management/email-triage` |
| Email Drafting | `/features/inbox-management/email-drafting` |
| Meeting Prep | `/features/meeting-assistant/meeting-prep` |
| Smart Scheduling | `/features/meeting-assistant/scheduling` |

Titles, icons, and descriptions pulled from each page's frontmatter so the homepage stays consistent with the docs.

Previewed locally via `mint dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)