### PR TITLE
homepage: title-case hero heading

### DIFF
--- a/index.mdx
+++ b/index.mdx
@@ -5,7 +5,7 @@ icon: 'sparkles'
 sidebarTitle: 'What is Lindy?'
 ---
 
-## The ultimate AI executive assistant
+## The Ultimate AI Executive Assistant
 
 Lindy is an AI executive assistant that runs your work life autonomously, giving you 10+ hours back every week. Set up in two minutes. No new tools to learn.
 


### PR DESCRIPTION
Fixes the hero H2 to use Title Case ("The Ultimate AI Executive Assistant") so it matches every other H2 on the homepage (What Lindy Does for You, How Lindy Is Different, etc.). Follow-up to #255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)