### PR TITLE
follow-ups: add spacing before callout

### DIFF
--- a/features/meeting-assistant/follow-ups.mdx
+++ b/features/meeting-assistant/follow-ups.mdx
@@ -59,6 +59,8 @@ Other examples:
   <img src="/lindy-brand-assets/follow-up-actions-recap-matt.png" alt="Texting Lindy 'Send me a recap of my call with Matt' and getting back 'Done 👍' then 'Should I also send those notes to Matt?' — 'Yes' — 'Done. Sent.' alongside a Gmail summary email labeled 'Drafted by Lindy' listing the meeting action items" />
 </Frame>
 
+<br />
+
 <Tip>
 This page covers post-meeting follow-ups. Lindy can also draft follow-up emails when someone hasn't replied to a message you sent. See [Email Drafting](/features/inbox-management/email-drafting) for that feature.
 </Tip>


### PR DESCRIPTION
Adds a `<br />` between the recap image and the callout on the follow-ups page so they aren't cramped together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)