### PR TITLE
quickstart: fix card whitespace

### DIFF
--- a/start-here/quickstart.mdx
+++ b/start-here/quickstart.mdx
@@ -43,22 +43,22 @@ Lindy is the AI that runs your work life. Once you're set up, Lindy autonomously
 Once you're set up, Lindy starts working right away. No configuration needed. One assistant replaces your entire work stack. Click any feature to dive deeper.
 
 <CardGroup cols={2}>
-  <Card title="Inbox Management" icon="inbox" href="/features/inbox-management/email-triage" horizontal>
+  <Card title="Inbox Management" icon="inbox" href="/features/inbox-management/email-triage">
     Triages, prioritizes, drafts, and sends replies in your voice — autonomously.
   </Card>
-  <Card title="Meeting Prep" icon="clipboard-list" href="/features/meeting-assistant/meeting-prep" horizontal>
+  <Card title="Meeting Prep" icon="clipboard-list" href="/features/meeting-assistant/meeting-prep">
     Researches attendees and delivers a briefing before every meeting.
   </Card>
-  <Card title="Meeting Notes" icon="microphone" href="/features/meeting-assistant/meeting-notes" horizontal>
+  <Card title="Meeting Notes" icon="microphone" href="/features/meeting-assistant/meeting-notes">
     Joins your meetings, records them, and generates interactive, searchable summaries.
   </Card>
-  <Card title="Follow-ups" icon="paper-plane" href="/features/meeting-assistant/follow-ups" horizontal>
+  <Card title="Follow-ups" icon="paper-plane" href="/features/meeting-assistant/follow-ups">
     Tracks action items and sends follow-up emails to attendees.
   </Card>
-  <Card title="Smart Scheduling" icon="calendar" href="/features/meeting-assistant/scheduling" horizontal>
+  <Card title="Smart Scheduling" icon="calendar" href="/features/meeting-assistant/scheduling">
     Finds times, sends invites, and locks in meetings — no more back-and-forth.
   </Card>
-  <Card title="Daily Briefings" icon="newspaper" href="/features/meeting-assistant/daily-brief" horizontal>
+  <Card title="Daily Briefings" icon="newspaper" href="/features/meeting-assistant/daily-brief">
     Sends you a morning briefing with your calendar, important emails, and news.
   </Card>
 </CardGroup>


### PR DESCRIPTION
Removes the `horizontal` prop from the six cards in the "What Lindy Does Automatically" section. In a 2-column grid with multi-line descriptions, horizontal cards forced equal-height cells and vertically-centered their content, leaving large empty space at the top of each card. Standard (vertical) cards top-align icon → title → text and fill the space cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)