### PR TITLE
daily-brief: text/iMessage-only delivery (drop email)

### DIFF
--- a/features/meeting-assistant/daily-brief.mdx
+++ b/features/meeting-assistant/daily-brief.mdx
@@ -21,7 +21,7 @@ keywords: ['daily brief', 'briefing', 'morning summary', 'day overview', 'news']
   </div>
 </div>
 
-Lindy can send you a daily brief on anything you prompt it to cover. Tell it exactly what you want: your schedule, who you're meeting, industry news, priorities. It lands in your inbox every morning before your day starts.
+Lindy can send you a daily brief on anything you prompt it to cover. Tell it exactly what you want: your schedule, who you're meeting, industry news, priorities. It arrives as a text on your phone every morning before your day starts.
 
 ## What You Can Include
 
@@ -42,13 +42,12 @@ Lindy reads your calendar, pulls relevant context, and delivers a clean summary 
 ## What It Looks Like
 
 <Frame>
-  <img src="/lindy-brand-assets/daily-briefing.jpg" alt="Daily brief email showing schedule, meeting attendees, and industry news" />
+  <img src="/lindy-brand-assets/daily-briefing.jpg" alt="Daily brief text showing schedule, meeting attendees, and industry news" />
 </Frame>
 
 ## How You Receive It
 
-- **Email**: lands in your inbox each morning
-- **SMS / iMessage**: sent directly to your phone
+Your brief arrives as a text — SMS or iMessage — sent directly to your phone each morning.
 
 ## How to Set It Up
 
@@ -61,10 +60,7 @@ Lindy reads your calendar, pulls relevant context, and delivers a clean summary 
     Describe what you want Lindy to cover each morning. Be as specific as you like — topics, format, level of detail.
   </Step>
   <Step title="Set your delivery time">
-    Choose when the brief arrives. Most people set it 30–60 minutes before their workday starts.
-  </Step>
-  <Step title="Choose your delivery method">
-    Select email, SMS / iMessage, or both.
+    Choose when the brief arrives. Most people set it 30–60 minutes before their workday starts. Your brief is delivered by text (SMS / iMessage).
   </Step>
 </Steps>
 

--- a/features/meeting-assistant/daily-brief.mdx
+++ b/features/meeting-assistant/daily-brief.mdx
@@ -47,7 +47,7 @@ Lindy reads your calendar, pulls relevant context, and delivers a clean summary 
 
 ## How You Receive It
 
-Your brief arrives as a text — SMS or iMessage — sent directly to your phone each morning.
+Lindy texts your brief straight to your phone (SMS / iMessage) at your preferred time each morning. There's nothing to check — it just shows up.
 
 ## How to Set It Up
 
@@ -59,8 +59,8 @@ Your brief arrives as a text — SMS or iMessage — sent directly to your phone
   <Step title="Write your prompt">
     Describe what you want Lindy to cover each morning. Be as specific as you like — topics, format, level of detail.
   </Step>
-  <Step title="Set your delivery time">
-    Choose when the brief arrives. Most people set it 30–60 minutes before their workday starts. Your brief is delivered by text (SMS / iMessage).
+  <Step title="Set your time">
+    Choose when Lindy texts you the brief. Most people set it 30–60 minutes before their workday starts.
   </Step>
 </Steps>
 


### PR DESCRIPTION
Daily brief no longer supports email delivery — it's text (SMS / iMessage) only.

- Intro: "lands in your inbox" → "arrives as a text on your phone"
- Image alt: "Daily brief email" → "Daily brief text"
- **How You Receive It**: removed the Email option; now text only
- **Setup**: removed the "Choose your delivery method" step and noted delivery is by text

(Left line 33's "emails" reference intact — that's about brief *content*, not delivery.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)