### PR TITLE
daily-brief: timing copy tweak

### DIFF
--- a/features/meeting-assistant/daily-brief.mdx
+++ b/features/meeting-assistant/daily-brief.mdx
@@ -64,7 +64,7 @@ Lindy texts your brief straight to your phone (SMS / iMessage) at your preferred
     Describe what you want Lindy to cover each morning. Be as specific as you like — topics, format, level of detail.
   </Step>
   <Step title="Set your time">
-    Choose when Lindy texts you the brief. Most people set it 30–60 minutes before their workday starts.
+    Choose when Lindy texts you the brief. Most people set it 30–60 minutes after they wake up, so they start the day already on top of what matters.
   </Step>
 </Steps>
 


### PR DESCRIPTION
Updates the timing guidance: "30–60 minutes before their workday starts" → "30–60 minutes after they wake up, so they start the day already on top of what matters."

🤖 Generated with [Claude Code](https://claude.com/claude-code)