### PR TITLE
meeting docs: add "How to Set It Up" settings notes

### DIFF
--- a/features/meeting-assistant/follow-ups.mdx
+++ b/features/meeting-assistant/follow-ups.mdx
@@ -13,6 +13,12 @@ After every meeting, Lindy extracts the action items and sends a follow-up email
   <img src="/lindy-brand-assets/follow-ups-recap-hero.png" alt="Texting Lindy 'Recap my call with Matt' and getting back 'Done. Notes sent 👍' alongside a 'Meeting with Matt' Key Takeaways card prepared by Lindy" />
 </Frame>
 
+## How to Set It Up
+
+<Note>
+  Open Lindy, click your **workspace name** in the top-left, and choose **Settings**. In the left sidebar, click **Meetings** — that's where you choose who receives follow-ups and add custom **Follow-up Actions**.
+</Note>
+
 ## How It Works
 
 When meeting recording is enabled, Lindy automatically handles follow-ups:

--- a/features/meeting-assistant/meeting-notes.mdx
+++ b/features/meeting-assistant/meeting-notes.mdx
@@ -9,6 +9,12 @@ keywords: ['meeting notes', 'transcript', 'summary', 'recording', 'minutes', 'me
   <img src="/lindy-brand-assets/meeting-library-imessage.png" alt="Lindy iMessage 'Saved your notes from the Matt call to your meeting library.' above the Meeting Library grid of recorded meetings" />
 </Frame>
 
+## How to Set It Up
+
+<Note>
+  Open Lindy, click your **workspace name** in the top-left, and choose **Settings**. In the left sidebar, click **Meetings** to toggle recording and adjust your notetaker and summary settings.
+</Note>
+
 ## Supported Platforms
 
 Lindy records meetings on **Google Meet**, **Zoom**, and **Microsoft Teams**.

--- a/features/meeting-assistant/meeting-prep.mdx
+++ b/features/meeting-assistant/meeting-prep.mdx
@@ -23,6 +23,12 @@ keywords: ['meeting prep', 'briefing', 'agenda', 'preparation']
 
 Delegate meeting prep to Lindy. Before every call, a briefing lands in your inbox or on your phone with who you're meeting, what you've discussed before, and what's on the agenda. You don't have to ask.
 
+## How to Set It Up
+
+<Note>
+  Open Lindy, click your **workspace name** in the top-left, and choose **Settings**. In the left sidebar, click **Meetings**, then scroll to **Meeting prep**.
+</Note>
+
 ## What's Included
 
 | Section | Details |


### PR DESCRIPTION
Users weren't sure how to reach each feature's settings. Adds a consistent **How to Set It Up** Note (no images) to Meeting Prep, Meeting Notes, and Follow-ups, pointing to **workspace name → Settings → Meetings**, matching the existing Daily Brief page. Each note also surfaces in the page's right-hand TOC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)