### PR TITLE
inbox docs: add "How to Set It Up" notes (drafting, labels)

### DIFF
--- a/features/inbox-management/email-drafting.mdx
+++ b/features/inbox-management/email-drafting.mdx
@@ -9,6 +9,12 @@ keywords: ['email draft', 'reply', 'compose', 'write email', 'auto reply']
 
 After [Email Triage](/features/inbox-management/email-triage) sorts your inbox, Lindy drafts replies for emails that need a response. Every draft lands in your drafts folder for you to review, edit, and send. Nothing goes out without your approval.
 
+## How to Set It Up
+
+<Note>
+  Open Lindy, click your **workspace name** in the top-left, and choose **Settings**. In the left sidebar, click **Emails**, then scroll to **Email drafting**.
+</Note>
+
 ## How It Works
 
 Enable email drafting in your settings at [chat.lindy.ai](https://chat.lindy.ai). Look for **Email drafting** in the settings panel. Once on, Lindy will:

--- a/features/inbox-management/email-triage.mdx
+++ b/features/inbox-management/email-triage.mdx
@@ -13,6 +13,12 @@ keywords: ['email triage', 'inbox', 'labels', 'prioritize', 'sort', 'categorize'
 
 Lindy automatically labels and sorts every incoming email into categories. Important messages stay front and center. Everything else gets filed away. No rules to write, no filters to manage. The more you use Lindy, the better it gets at understanding what matters to you.
 
+## How to Set It Up
+
+<Note>
+  Open Lindy, click your **workspace name** in the top-left, and choose **Settings**. In the left sidebar, click **Emails**, then scroll to **Email labeling**.
+</Note>
+
 ## Email Labeling
 
 Lindy reads every incoming email and assigns it to the right category. Email labeling is **on by default**. You can adjust it anytime in your settings at [chat.lindy.ai](https://chat.lindy.ai).


### PR DESCRIPTION
Adds the consistent **How to Set It Up** Note to Email Drafting and Email Triage (labels), pointing to **workspace name → Settings → Emails**, matching the meeting-assistant pages.

- Email Drafting → scroll to **Email drafting**
- Email Triage → scroll to **Email labeling**

🤖 Generated with [Claude Code](https://claude.com/claude-code)