### PR TITLE
follow-ups: note connected tools + auth in follow-up actions

### DIFF
--- a/features/meeting-assistant/follow-ups.mdx
+++ b/features/meeting-assistant/follow-ups.mdx
@@ -37,6 +37,8 @@ When meeting recording is enabled, Lindy automatically handles follow-ups:
 
 Beyond email, you can tell Lindy to take additional actions after meetings. In your settings at [chat.lindy.ai](https://chat.lindy.ai), use the **Follow-up Actions** field to describe what Lindy should do.
 
+Lindy connects to many of your tools — Slack, your CRM, Notion, and more. Just name the tool in your instructions and tell Lindy how to use it (what to create, update, or send). The first time a follow-up runs an action in a new tool, Lindy will ask you to authenticate it.
+
 <Frame>
   <img src="/lindy-brand-assets/follow-up-actions-settings.jpg" alt="Follow-up actions settings showing custom actions and notification options" />
 </Frame>


### PR DESCRIPTION
Adds a line to Custom Follow-up Actions explaining that Lindy connects to many tools (Slack, CRM, Notion, etc.) — name the tool in your instructions and say how Lindy should use it — and that Lindy will prompt you to authenticate the first time a follow-up runs an action in a new tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)