### PR TITLE
follow-ups: make connected-tools note a callout

### DIFF
--- a/features/meeting-assistant/follow-ups.mdx
+++ b/features/meeting-assistant/follow-ups.mdx
@@ -37,7 +37,9 @@ When meeting recording is enabled, Lindy automatically handles follow-ups:
 
 Beyond email, you can tell Lindy to take additional actions after meetings. In your settings at [chat.lindy.ai](https://chat.lindy.ai), use the **Follow-up Actions** field to describe what Lindy should do.
 
-Lindy connects to many of your tools — Slack, your CRM, Notion, and more. Just name the tool in your instructions and tell Lindy how to use it (what to create, update, or send). The first time a follow-up runs an action in a new tool, Lindy will ask you to authenticate it.
+<Note>
+  **Lindy connects to your tools.** Name any connected app in your instructions — Slack, your CRM, Notion, and more — and tell Lindy how to use it (what to create, update, or send). The first time a follow-up runs an action in a new tool, **Lindy will ask you to authenticate it.**
+</Note>
 
 <Frame>
   <img src="/lindy-brand-assets/follow-up-actions-settings.jpg" alt="Follow-up actions settings showing custom actions and notification options" />


### PR DESCRIPTION
Promotes the connected-tools + first-time-authentication line into an explicit `<Note>` callout (with bolded key points) so it's obvious, instead of a plain paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)