### PR TITLE
follow-ups: sharpen connected-tools callout copy

### DIFF
--- a/features/meeting-assistant/follow-ups.mdx
+++ b/features/meeting-assistant/follow-ups.mdx
@@ -38,7 +38,7 @@ When meeting recording is enabled, Lindy automatically handles follow-ups:
 Beyond email, you can tell Lindy to take additional actions after meetings. In your settings at [chat.lindy.ai](https://chat.lindy.ai), use the **Follow-up Actions** field to describe what Lindy should do.
 
 <Note>
-  **Lindy connects to your tools.** Name any connected app in your instructions — Slack, your CRM, Notion, and more — and tell Lindy how to use it (what to create, update, or send). The first time a follow-up runs an action in a new tool, **Lindy will ask you to authenticate it.**
+  **Lindy works inside the tools you already use** — Notion, Slack, Todoist, and hundreds more. Just name the app in your instructions and say what you want done: *"Add action items to Todoist," "Post the recap in #team-sales," "Create a Notion page for every client call."* Lindy handles the rest, and asks you to connect the app the first time it needs it.
 </Note>
 
 <Frame>


### PR DESCRIPTION
Rewrites the connected-tools callout to be more concrete and benefit-led: leads with "works inside the tools you already use," adds real example prompts (Todoist, Slack, Notion), and folds the first-time-auth point into the closer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)