### PR TITLE
follow-ups: tighten connected-tools callout

### DIFF
--- a/features/meeting-assistant/follow-ups.mdx
+++ b/features/meeting-assistant/follow-ups.mdx
@@ -38,7 +38,7 @@ When meeting recording is enabled, Lindy automatically handles follow-ups:
 Beyond email, you can tell Lindy to take additional actions after meetings. In your settings at [chat.lindy.ai](https://chat.lindy.ai), use the **Follow-up Actions** field to describe what Lindy should do.
 
 <Note>
-  **Lindy works inside the tools you already use** — Notion, Slack, Todoist, and hundreds more. Just name the app in your instructions and say what you want done: *"Add action items to Todoist," "Post the recap in #team-sales," "Create a Notion page for every client call."* Lindy handles the rest, and asks you to connect the app the first time it needs it.
+  **Lindy works with your existing tools** — Notion, Slack, Todoist, and hundreds more. Just tell it what to do (*"Add action items to Todoist"*) and it handles the rest. The first time it uses an app, Lindy asks you to connect it.
 </Note>
 
 <Frame>


### PR DESCRIPTION
Tightens the connected-tools callout: "Lindy works with your existing tools — Notion, Slack, Todoist, and hundreds more. Just tell it what to do and it handles the rest. First time it uses an app, Lindy asks you to connect it."

🤖 Generated with [Claude Code](https://claude.com/claude-code)