### PR TITLE
follow-ups: line break in tools callout

### DIFF
--- a/features/meeting-assistant/follow-ups.mdx
+++ b/features/meeting-assistant/follow-ups.mdx
@@ -38,7 +38,9 @@ When meeting recording is enabled, Lindy automatically handles follow-ups:
 Beyond email, you can tell Lindy to take additional actions after meetings. In your settings at [chat.lindy.ai](https://chat.lindy.ai), use the **Follow-up Actions** field to describe what Lindy should do.
 
 <Note>
-  **Lindy works with your existing tools** — Notion, Slack, Todoist, and hundreds more. Just tell it what to do (*"Add action items to Todoist"*) and it handles the rest. The first time it uses an app, Lindy asks you to connect it.
+  **Lindy works with your existing tools** — Notion, Slack, Todoist, and hundreds more. Just tell it what to do (*"Add action items to Todoist"*) and it handles the rest.
+
+  The first time it uses an app, Lindy asks you to connect it.
 </Note>
 
 <Frame>


### PR DESCRIPTION
Adds a paragraph break before "The first time it uses an app, Lindy asks you to connect it." in the connected-tools callout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)