### PR TITLE
Add Chrome Extension documentation page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -60,6 +60,12 @@
             ]
           },
           {
+            "group": "Chrome Extension",
+            "pages": [
+              "features/chrome-extension"
+            ]
+          },
+          {
             "group": "Meeting Assistant",
             "pages": [
               "features/meeting-assistant/daily-brief",

--- a/features/chrome-extension.mdx
+++ b/features/chrome-extension.mdx
@@ -1,0 +1,112 @@
+---
+title: 'Chrome Extension'
+description: 'Lindy runs inside Gmail. Triaged inbox, a morning brief, drafted replies, and a sidebar chat, all without leaving your tab.'
+icon: 'chrome'
+keywords: ['chrome extension', 'gmail', 'browser extension', 'sidebar', 'compose', 'install', 'morning brief']
+---
+
+## Lindy, Inside Gmail
+
+Open Gmail and Lindy is already working. Your inbox is triaged with color-coded labels, a morning brief tells you what happened overnight, and every email that needs a response has a draft waiting. Everything's written in your voice and ready to send in one click.
+
+<Note>
+The Chrome extension is currently **Gmail only**. Outlook is coming soon.
+</Note>
+
+## Installing the Extension
+
+<Steps>
+  <Step title="Add Lindy to Chrome">
+    Install the Lindy extension from the Chrome Web Store and pin it to your toolbar.
+  </Step>
+  <Step title="Open Gmail">
+    Head to your Gmail tab. Lindy loads automatically inside the inbox.
+  </Step>
+  <Step title="Connect your account">
+    Sign in with the Lindy account you use at [chat.lindy.ai](https://chat.lindy.ai). Your settings, labels, and drafting instructions carry over.
+  </Step>
+</Steps>
+
+## What You Get
+
+<CardGroup cols={2}>
+  <Card title="Triage labels" icon="tags">
+    Every email is sorted and tagged with color-coded label pills before you open your inbox.
+  </Card>
+  <Card title="Morning brief" icon="sun">
+    A daily card at the top of Gmail recaps what Lindy handled overnight.
+  </Card>
+  <Card title="Draft replies" icon="pen">
+    Pre-written responses in your voice, with quick-action buttons to send in one click.
+  </Card>
+  <Card title="Compose bar" icon="wand-magic-sparkles">
+    Rewrite, schedule, or ask Lindy anything right from the reply window.
+  </Card>
+  <Card title="Label learning" icon="graduation-cap">
+    Lindy learns from how you re-label emails and gets better over time.
+  </Card>
+  <Card title="Sidebar chat" icon="comments">
+    A floating or docked panel to chat with Lindy without leaving Gmail.
+  </Card>
+</CardGroup>
+
+## Triage Labels
+
+Lindy reads every incoming email and assigns it to the right category, shown as color-coded label pills right in your inbox list. Important messages stay front and center. Everything else gets filed away.
+
+Your labels and categories are shared with your main Lindy settings, so anything you set up at [chat.lindy.ai](https://chat.lindy.ai) shows up in the extension too.
+
+<Tip>
+Want to fine-tune your categories? See [Email Triage](/features/inbox-management/email-triage) for how labeling works and how to add your own.
+</Tip>
+
+## Morning Brief
+
+At the top of Gmail, a greeting card recaps what Lindy did while you were away, for example: *"Morning, Haneen! Labeled 14 emails for you today."* It's a quick read on the state of your inbox before you dig in.
+
+## Draft Replies
+
+Open an email that needs a response and Lindy's draft is already there, written in your voice. **Quick-action buttons** let you respond without typing: pick an intent like **Let's meet**, **Need time**, or **Not interested**, and Lindy shapes the reply for you.
+
+Review, edit, or send. Nothing goes out without your approval.
+
+<Tip>
+Drafts use the same drafting instructions as the rest of Lindy. See [Email Drafting](/features/inbox-management/email-drafting) to tune your tone, length, and sign-offs.
+</Tip>
+
+## Compose Bar
+
+Lindy replaces Gmail's "Help me write" compose tool with an input that actually knows your context. From the reply window you can:
+
+- **Rewrite**: reshape a draft to be shorter, warmer, or more direct
+- **Schedule**: turn an email thread into a meeting
+- **Ask anything**: type a request and Lindy handles it inline
+
+Just type into the compose bar (*"Schedule, rewrite, or ask Lindy anything..."*) and Lindy takes it from there.
+
+## Label Learning
+
+When you re-label an email, Lindy notices. A toast confirms it learned from the change (*"Lindy learnt from your label"*), and future emails get sorted accordingly. Teach Lindy once, and it remembers.
+
+## Sidebar Chat
+
+A Lindy chat panel lives inside Gmail, floating or docked to the side. Ask Lindy anything without switching tabs. The sidebar supports:
+
+- **Voice input**: speak instead of type
+- **File attachments**: bring in documents for Lindy to work with
+- **Model selector**: choose the model behind your chat
+
+## Security
+
+Lindy is **SOC 2**, **GDPR**, and **HIPAA** compliant. See [Security](/resources/security) for details on how your data is handled.
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Email Triage" icon="inbox" href="/features/inbox-management/email-triage">
+    How Lindy organizes and labels your inbox
+  </Card>
+  <Card title="Email Drafting" icon="pen" href="/features/inbox-management/email-drafting">
+    How Lindy drafts replies in your voice
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary
Adds a new documentation page for the Lindy Chrome extension, based on the Chrome Web Store listing brief.

- **`features/chrome-extension.mdx`** — covers the six Gmail-native features: triage labels, morning brief, draft replies (with quick-action buttons), compose bar, label learning, and sidebar chat. Includes an install section and a security note.
- **`docs.json`** — registers the page as a new "Chrome Extension" group in the Documentation tab.

## Notes
- Image placeholders omitted for now; sections are ready to drop screenshots into `lindy-brand-assets/` later.
- Follows repo messaging guidelines: AI-assistant voice, no em dashes, no competitor naming (phrased "Help me write" as Gmail's compose tool rather than naming Gemini).
- The brief's "New Tab takeover" feature was left out (referenced only via a Slack link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)