### PR TITLE
Clarify draft replies work with or without the extension

### DIFF
--- a/features/chrome-extension.mdx
+++ b/features/chrome-extension.mdx
@@ -78,9 +78,13 @@ At the top of Gmail, a greeting card recaps what Lindy did while you were away, 
 
 ## Draft Replies
 
-Open an email that needs a response and Lindy's draft is already there, written in your voice. **Quick-action buttons** let you respond without typing: pick an intent like **Let's meet**, **Need time**, or **Not interested**, and Lindy shapes the reply for you.
+Lindy drafts replies whether or not you use the extension: open an email that needs a response and the draft is already there, written in your voice. What the Chrome extension adds is the ability to shape that draft without ever leaving the draft window. **Quick-action buttons** let you respond without typing: pick an intent like **Let's meet**, **Need time**, or **Not interested**, and Lindy reshapes the reply right in place.
 
 Review, edit, or send. Nothing goes out without your approval.
+
+<Note>
+Drafting happens with or without the Chrome extension. The extension's value-add is editing those drafts inline: adjust the tone, pick a quick action, or ask for a change without ever leaving the draft window.
+</Note>
 
 <Frame>
   <img src="/lindy-brand-assets/chrome-extension/draft-replies.png" alt="A drafted reply in Gmail with quick-action buttons (Let's meet, Need time, Not interested) and the Lindy compose bar" style={{ width: '100%', borderRadius: '16px' }} />


### PR DESCRIPTION
Updates the Draft Replies section of `features/chrome-extension.mdx` to clarify that Lindy drafts replies with or without the Chrome extension, and that the extension's specific value-add is tweaking those drafts inline without ever leaving the draft window. Adds a `<Note>` callout to reinforce the distinction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)