### PR TITLE
Tighten Chrome extension draft-replies copy

### DIFF
--- a/features/chrome-extension.mdx
+++ b/features/chrome-extension.mdx
@@ -78,13 +78,9 @@ At the top of Gmail, a greeting card recaps what Lindy did while you were away, 
 
 ## Draft Replies
 
-Lindy drafts replies whether or not you use the extension: open an email that needs a response and the draft is already there, written in your voice. What the Chrome extension adds is the ability to shape that draft without ever leaving the draft window. **Quick-action buttons** let you respond without typing: pick an intent like **Let's meet**, **Need time**, or **Not interested**, and Lindy reshapes the reply right in place.
+Lindy drafts replies with or without the extension: open an email that needs a response and the draft is already there, written in your voice. What the Chrome extension adds is the ability to refine that draft inline, without ever leaving the draft window. Adjust the tone or ask for a change, or use **Quick-action buttons** to respond without typing: pick an intent like **Let's meet**, **Need time**, or **Not interested**, and Lindy reshapes the reply in place.
 
 Review, edit, or send. Nothing goes out without your approval.
-
-<Note>
-Drafting happens with or without the Chrome extension. The extension's value-add is editing those drafts inline: adjust the tone, pick a quick action, or ask for a change without ever leaving the draft window.
-</Note>
 
 <Frame>
   <img src="/lindy-brand-assets/chrome-extension/draft-replies.png" alt="A drafted reply in Gmail with quick-action buttons (Let's meet, Need time, Not interested) and the Lindy compose bar" style={{ width: '100%', borderRadius: '16px' }} />


### PR DESCRIPTION
Tightens the Draft Replies section on the Chrome extension page.

- Removes the `<Note>` that restated the paragraph almost verbatim
- Folds its one unique detail (adjust tone / ask for a change) into the main paragraph so the extension's value-add is stated once
- Minor tightening ("whether or not you use" → "with or without"; drops redundant "right")

🤖 Generated with [Claude Code](https://claude.com/claude-code)