### PR TITLE
Remove Morning Brief section from Chrome extension page

### DIFF
--- a/features/chrome-extension.mdx
+++ b/features/chrome-extension.mdx
@@ -68,14 +68,6 @@ Your labels and categories are shared with your main Lindy settings, so anything
 Want to fine-tune your categories? See [Email Triage](/features/inbox-management/email-triage) for how labeling works and how to add your own.
 </Tip>
 
-## Morning Brief
-
-At the top of Gmail, a greeting card recaps what Lindy did while you were away, for example: *"Morning, Haneen! Labeled 14 emails for you today."* It's a quick read on the state of your inbox before you dig in.
-
-<Frame>
-  <img src="/lindy-brand-assets/chrome-extension/daily-brief.png" alt="Morning brief card: 'Morning, Flo! Labeled 48 emails and drafted 5 replies' with important items to catch up on" style={{ width: '100%', borderRadius: '16px' }} />
-</Frame>
-
 ## Draft Replies
 
 Lindy drafts replies with or without the extension: open an email that needs a response and the draft is already there, written in your voice. What the Chrome extension adds is the ability to refine that draft inline, without ever leaving the draft window. Adjust the tone or ask for a change, or use **Quick-action buttons** to respond without typing: pick an intent like **Let's meet**, **Need time**, or **Not interested**, and Lindy reshapes the reply in place.


### PR DESCRIPTION
Removes the **Morning Brief** section (heading, paragraph, and image) from the Chrome extension page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)