### PR TITLE
Rewrite Draft Replies section for clarity

### DIFF
--- a/features/chrome-extension.mdx
+++ b/features/chrome-extension.mdx
@@ -70,9 +70,17 @@ Want to fine-tune your categories? See [Email Triage](/features/inbox-management
 
 ## Draft Replies
 
-Lindy drafts replies with or without the extension: open an email that needs a response and the draft is already there, written in your voice. What the Chrome extension adds is the ability to refine that draft inline, without ever leaving the draft window. Adjust the tone or ask for a change, or use **Quick-action buttons** to respond without typing: pick an intent like **Let's meet**, **Need time**, or **Not interested**, and Lindy reshapes the reply in place.
+Lindy drafts replies automatically, even if you don't have the Chrome extension installed. Open an email that needs a response, and your draft is already there, written in your voice.
 
-Review, edit, or send. Nothing goes out without your approval.
+The Chrome extension lets you refine that draft without leaving Gmail.
+
+Use **Quick actions** like **Let's meet**, **Need time**, or **Not interested**, or simply ask Lindy to make changes. The draft updates instantly, right where you're working.
+
+Review, edit, or send - nothing is ever sent without your approval.
+
+<Note>
+Drafting works with or without the Chrome extension. The extension simply makes editing faster by letting you adjust tone, choose a quick action, or request changes directly inside the draft.
+</Note>
 
 <Frame>
   <img src="/lindy-brand-assets/chrome-extension/draft-replies.png" alt="A drafted reply in Gmail with quick-action buttons (Let's meet, Need time, Not interested) and the Lindy compose bar" style={{ width: '100%', borderRadius: '16px' }} />


### PR DESCRIPTION
Rewrites the **Draft Replies** section on the Chrome extension page for clarity:

- Leads with drafting working automatically, with or without the extension
- Separates the extension's inline-refine value into its own line
- Clarifies Quick actions + "ask Lindy to make changes" with instant updates
- Restores a `<Note>` callout summarizing that drafting works either way

🤖 Generated with [Claude Code](https://claude.com/claude-code)