### PR TITLE
Docs: un-bold active tab + even image frame spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -951,6 +951,12 @@ html:not(.dark) #topbar-cta-button > a > span.absolute {
   color: #C4D0DC !important;
 }
 
+/* Don't fake-bold the selected top nav tab (Mintlify thickens it with a text-shadow) */
+.nav-tabs-item[data-active="true"],
+a.nav-tabs-item[data-active="true"] {
+  text-shadow: none !important;
+}
+
 /* Dark mode: Tab content text */
 .dark .tabs .text-gray-600,
 .dark .tabs .text-gray-500,
@@ -1321,9 +1327,10 @@ figure {
   line-height: 0; /* Remove line-height spacing */
 }
 
-/* Even vertical spacing around top-level frames (image had margin:0, so gaps were uneven) */
+/* Even vertical spacing around top-level frames. Frame is not-prose so it's excluded
+   from Mintlify's ~2em prose flow rhythm; match that 2em so gaps above/below are even. */
 .frame {
-  margin: 1.5rem 0 !important;
+  margin: 2em 0 !important;
 }
 
 /* Ensure images fill their containers completely */


### PR DESCRIPTION
CSS-only polish.

- **Active top tab:** removed Mintlify's `text-shadow` faux-bold so the selected tab matches the others in weight (still marked by amber color + underline)
- **Image frames:** `.frame` is `not-prose` and was excluded from Mintlify's ~2em prose rhythm; set it to `2em` vertical margin so gaps above/below images are even (fixes Chrome extension page spacing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)