### PR TITLE
usage: use a more general Teammate hero

### DIFF
--- a/account-billing/usage.mdx
+++ b/account-billing/usage.mdx
@@ -7,7 +7,7 @@ keywords: ['usage', 'limits', 'usage warning', 'credits', 'shared credit pool', 
 ---
 
 <Frame>
-  <img src="/lindy-brand-assets/teammate/launch-banner.png" alt="A teammate delegating support triage to Lindy in Slack" />
+  <img src="/lindy-brand-assets/teammate/asset-3-capabilities-grid.png" alt="The range of work teams delegate to Lindy in Slack: asking, acting, and creating" />
 </Frame>
 
 Your whole team draws from **one shared pool of credits**. Every seat adds to it, and every Lindy your team works with spends from it: the shared Lindy out in your channels, and the private Lindy in each person's DMs.


### PR DESCRIPTION
Follow-up to #303. The hero there (`launch-banner.png`) illustrated one specific ask, "can you take support triage today?", which read as too narrow for a page about overall credit usage.

Swaps in `teammate/asset-3-capabilities-grid.png`: four cards spanning **ASK / ACT / CREATE** (deal pulse, asking across every meeting, offloading a task handoff, building a weekly business review). It shows the range of work teams delegate, which is what the credit tables directly below it enumerate.

Considered and passed on:
- `setup-investigate-hero.png` (4800x2520, best resolution, perfect 1.90 ratio) but it's a single investigation, same too-specific problem
- `hero-banner.png` is nicely general but only 1122x596, too soft for a hero
- `lindy-for-teams-banner-v2.png` is general but reads as a launch banner rather than showing work

Image was already committed to the repo. Copy is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)