### PR TITLE
usage: rate meeting recaps and notes as Low

### DIFF
--- a/account-billing/usage.mdx
+++ b/account-billing/usage.mdx
@@ -53,7 +53,7 @@ Private to each person, and much lighter. These run on their own to keep you ahe
 | Open-loop nudges when an ask goes unanswered | Very low |
 | Meeting prep briefings | Very low |
 | Catch-up summaries when you're @mentioned in a busy channel | Low |
-| Meeting recaps and notes | Moderate |
+| Meeting recaps and notes | Low |
 | Ad hoc research you delegate in a DM | **Varies** |
 
 <Note>


### PR DESCRIPTION
Changes **Meeting recaps and notes** from `Moderate` to `Low` in the personal Lindy table.

Checked that nothing else on the page contradicts it: the "Record only the meetings you need notes on" accordion, which called recording "one of the heavier things Lindy does", was already dropped in the Teammate revamp (#303).

The row now sits alongside catch-up summaries in the Low band, so the table still reads Very low → Low → Varies in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)