### PR TITLE
docs: move Teammate pages off /coming-soon/* to /teammate/*

### DIFF
--- a/account-billing/usage.mdx
+++ b/account-billing/usage.mdx
@@ -12,7 +12,7 @@ keywords: ['usage', 'limits', 'usage warning', 'credits', 'shared credit pool', 
 
 Your whole team draws from **one shared pool of credits**. Every seat adds to it, and every Lindy your team works with spends from it: the shared Lindy out in your channels, and the private Lindy in each person's DMs.
 
-This page covers what actually uses credits, why Lindy sometimes pauses to check in, and what to do if your team needs more. For seats, pricing, and trials, see [Lindy Teammate Billing](/coming-soon/lindy-teammate-billing).
+This page covers what actually uses credits, why Lindy sometimes pauses to check in, and what to do if your team needs more. For seats, pricing, and trials, see [Lindy Teammate Billing](/teammate/billing).
 
 ## Usage Warning: Why Am I Seeing This?
 
@@ -93,7 +93,7 @@ Admins have three options:
 </Accordion>
 
 <Accordion title="Does adding a teammate add credits?">
-Yes. Credits belong to the workspace, not to each person, and every seat adds its tier's allotment to the pool. A Plus seat adds 3,000, a Pro seat 15,000, and so on. Someone who joins by @mentioning Lindy in Slack gets a free first week before their seat converts to paid. See [Lindy Teammate Billing](/coming-soon/lindy-teammate-billing).
+Yes. Credits belong to the workspace, not to each person, and every seat adds its tier's allotment to the pool. A Plus seat adds 3,000, a Pro seat 15,000, and so on. Someone who joins by @mentioning Lindy in Slack gets a free first week before their seat converts to paid. See [Lindy Teammate Billing](/teammate/billing).
 </Accordion>
 
 <Accordion title="Will paused tasks pick up automatically?">
@@ -116,7 +116,7 @@ Most teams never come close to their limit. If you want to stretch the pool furt
   <Accordion title="Review team routines monthly">
     Team routines run on their own schedule whether or not anyone reads the result, and a workspace-wide routine spends for the whole team every time it fires. They're the easiest thing to set up and forget.
 
-    Open the **Routines** page from the left sidebar and review both the **Team** and **Personal** tabs once a month. Flipping a routine off stops it without removing it, so you can turn it back on whenever you want. See [Routines](/coming-soon/routines).
+    Open the **Routines** page from the left sidebar and review both the **Team** and **Personal** tabs once a month. Flipping a routine off stops it without removing it, so you can turn it back on whenever you want. See [Routines](/teammate/routines).
   </Accordion>
 
   <Accordion title="Start a new thread for a new topic">
@@ -170,10 +170,10 @@ If your team exceeds the pool's limit, overage usage is charged at **2x your pla
 ## Relevant Docs
 
 <CardGroup cols={2}>
-  <Card title="Lindy Teammate Billing" icon="credit-card" href="/coming-soon/lindy-teammate-billing">
+  <Card title="Lindy Teammate Billing" icon="credit-card" href="/teammate/billing">
     Seats, trials, top-ups, and your shared credit pool
   </Card>
-  <Card title="Lindy Teammate" icon="slack" href="/coming-soon/lindy-teammate">
+  <Card title="Lindy Teammate" icon="slack" href="/teammate/overview">
     What Lindy does in your team's Slack, per person and per team
   </Card>
 </CardGroup>

--- a/docs.json
+++ b/docs.json
@@ -3,6 +3,15 @@
   "theme": "maple",
   "name": "Lindy Documentation",
   "redirects": [
+    { "source": "/coming-soon/setup", "destination": "/teammate/setup", "permanent": true },
+    { "source": "/coming-soon/home", "destination": "/teammate/home", "permanent": true },
+    { "source": "/coming-soon/meeting-library", "destination": "/teammate/meeting-library", "permanent": true },
+    { "source": "/coming-soon/files", "destination": "/teammate/files", "permanent": true },
+    { "source": "/coming-soon/routines", "destination": "/teammate/routines", "permanent": true },
+    { "source": "/coming-soon/skills", "destination": "/teammate/skills", "permanent": true },
+    { "source": "/coming-soon/slack-commands", "destination": "/teammate/slack-commands", "permanent": true },
+    { "source": "/coming-soon/lindy-teammate", "destination": "/teammate/overview", "permanent": true },
+    { "source": "/coming-soon/lindy-teammate-billing", "destination": "/teammate/billing", "permanent": true },
     { "source": "/CLAUDE", "destination": "/", "permanent": true },
     { "source": "/WORKFLOW", "destination": "/", "permanent": true },
     { "source": "/account-billing/multi-account", "destination": "/features/inbox-management/email-drafting", "permanent": true },
@@ -45,13 +54,13 @@
       {
         "group": "Lindy Teammate",
         "pages": [
-          "coming-soon/setup",
-          "coming-soon/home",
-          "coming-soon/meeting-library",
-          "coming-soon/files",
-          "coming-soon/routines",
-          "coming-soon/skills",
-          "coming-soon/slack-commands"
+          "teammate/setup",
+          "teammate/home",
+          "teammate/meeting-library",
+          "teammate/files",
+          "teammate/routines",
+          "teammate/skills",
+          "teammate/slack-commands"
         ]
       },
       {
@@ -92,7 +101,7 @@
         "pages": [
           "pricing",
           "account-billing/usage",
-          "coming-soon/lindy-teammate-billing"
+          "teammate/billing"
         ]
       },
       {

--- a/features/inbox-management/email-alerting.mdx
+++ b/features/inbox-management/email-alerting.mdx
@@ -61,7 +61,7 @@ At the top of the drawer, each connected inbox shows as a chip, with a **+ Add a
   <Card title="Email Triage" icon="inbox" href="/features/inbox-management/email-triage">
     How Lindy labels and organizes your inbox
   </Card>
-  <Card title="Routines" icon="clock-rotate-left" href="/coming-soon/routines">
+  <Card title="Routines" icon="clock-rotate-left" href="/teammate/routines">
     Manage alerting and your other routines
   </Card>
 </CardGroup>

--- a/features/inbox-management/email-drafting.mdx
+++ b/features/inbox-management/email-drafting.mdx
@@ -71,7 +71,7 @@ Settings are per-inbox, so when you have more than one connected, select the acc
   <Card title="Email Triage" icon="inbox" href="/features/inbox-management/email-triage">
     How Lindy organizes your inbox
   </Card>
-  <Card title="Routines" icon="clock-rotate-left" href="/coming-soon/routines">
+  <Card title="Routines" icon="clock-rotate-left" href="/teammate/routines">
     Manage drafting, follow-ups, and your other routines
   </Card>
 </CardGroup>

--- a/features/inbox-management/email-triage.mdx
+++ b/features/inbox-management/email-triage.mdx
@@ -101,7 +101,7 @@ Lindy starts with a set of labels you can keep, edit, or remove:
   <Card title="Email Drafting" icon="pen" href="/features/inbox-management/email-drafting">
     How Lindy drafts replies in your voice
   </Card>
-  <Card title="Routines" icon="clock-rotate-left" href="/coming-soon/routines">
+  <Card title="Routines" icon="clock-rotate-left" href="/teammate/routines">
     Manage email labeling and your other routines
   </Card>
 </CardGroup>

--- a/features/inbox-management/follow-up-bumps.mdx
+++ b/features/inbox-management/follow-up-bumps.mdx
@@ -50,7 +50,7 @@ At the top of the drawer, each connected inbox shows as a chip, with a **+ Add a
   <Card title="Email Drafting" icon="pen" href="/features/inbox-management/email-drafting">
     How Lindy drafts replies in your voice
   </Card>
-  <Card title="Routines" icon="clock-rotate-left" href="/coming-soon/routines">
+  <Card title="Routines" icon="clock-rotate-left" href="/teammate/routines">
     Manage follow-up bumps and your other routines
   </Card>
 </CardGroup>

--- a/index.mdx
+++ b/index.mdx
@@ -78,10 +78,10 @@ Been out, or dropped into a busy channel? Lindy gives you the TL;DR and exactly 
 
 <div className="mini-cards">
   <a className="mini-card" href="/integrations/overview"><span className="mt">Connected to everything.</span> <span className="md">Works with Gmail, Slack, Notion, HubSpot, and 1,000+ tools, plus any MCP server.</span></a>
-  <a className="mini-card" href="/coming-soon/meeting-library"><span className="mt">Sits in every meeting.</span> <span className="md">Records and shares team meetings, so anyone can query them later.</span></a>
-  <a className="mini-card" href="/coming-soon/routines"><span className="mt">Shows up on schedule.</span> <span className="md">Runs recurring work like daily briefs and weekly reports automatically.</span></a>
-  <a className="mini-card" href="/coming-soon/skills"><span className="mt">Learns your skills.</span> <span className="md">Ships with 40+ skills, and saves new ones your team can reuse.</span></a>
-  <a className="mini-card" href="/coming-soon/files"><span className="mt">Editable memory.</span> <span className="md">Keeps what it knows in plain files you can open and edit.</span></a>
+  <a className="mini-card" href="/teammate/meeting-library"><span className="mt">Sits in every meeting.</span> <span className="md">Records and shares team meetings, so anyone can query them later.</span></a>
+  <a className="mini-card" href="/teammate/routines"><span className="mt">Shows up on schedule.</span> <span className="md">Runs recurring work like daily briefs and weekly reports automatically.</span></a>
+  <a className="mini-card" href="/teammate/skills"><span className="mt">Learns your skills.</span> <span className="md">Ships with 40+ skills, and saves new ones your team can reuse.</span></a>
+  <a className="mini-card" href="/teammate/files"><span className="mt">Editable memory.</span> <span className="md">Keeps what it knows in plain files you can open and edit.</span></a>
 </div>
 
 ## Security by design
@@ -99,7 +99,7 @@ Compliant, private, and in your control. Three separate promises, and Lindy keep
 ## Works wherever you work
 
 <div className="lindy-pills">
-  <a className="lindy-pill" href="/coming-soon/setup"><Icon icon="slack" size={15} /> Slack</a>
+  <a className="lindy-pill" href="/teammate/setup"><Icon icon="slack" size={15} /> Slack</a>
   <a className="lindy-pill" href="/features/imessage-sms"><Icon icon="message" size={15} /> iMessage</a>
   <a className="lindy-pill" href="/features/chrome-extension"><Icon icon="chrome" size={15} /> Chrome extension</a>
 </div>

--- a/pricing.mdx
+++ b/pricing.mdx
@@ -113,10 +113,10 @@ Need more before your cycle resets? Admins can top up shared credits any time at
   <Card title="Get Started" icon="rocket" href="/start-here/quickstart">
     Set up Lindy in 2 minutes.
   </Card>
-  <Card title="Lindy Teammate" icon="slack" href="/coming-soon/lindy-teammate">
+  <Card title="Lindy Teammate" icon="slack" href="/teammate/overview">
     Give your whole team a shared Lindy in Slack.
   </Card>
-  <Card title="Billing" icon="credit-card" href="/coming-soon/lindy-teammate-billing">
+  <Card title="Billing" icon="credit-card" href="/teammate/billing">
     Seats, trials, and your shared credit pool.
   </Card>
   <Card title="Security" icon="shield-halved" href="/resources/security">

--- a/start-here/quickstart.mdx
+++ b/start-here/quickstart.mdx
@@ -21,7 +21,7 @@ Two quick parts: get Lindy into your team's Slack, then connect your own email, 
   </Step>
 </Steps>
 
-For the full picture (how to talk to Lindy, guardrails, and what it can do), see [Set up Lindy](/coming-soon/setup).
+For the full picture (how to talk to Lindy, guardrails, and what it can do), see [Set up Lindy](/teammate/setup).
 
 ## 2. Set up your account
 
@@ -53,13 +53,13 @@ Ask Lindy in Slack, a DM, or by text:
 ## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="Set up Lindy" icon="slack" href="/coming-soon/setup">
+  <Card title="Set up Lindy" icon="slack" href="/teammate/setup">
     The full team and account setup
   </Card>
-  <Card title="Home" icon="house" href="/coming-soon/home">
+  <Card title="Home" icon="house" href="/teammate/home">
     Where you talk to Lindy and see what it's done
   </Card>
-  <Card title="Meetings" icon="video" href="/coming-soon/meeting-library">
+  <Card title="Meetings" icon="video" href="/teammate/meeting-library">
     Recording, notes, and your shared library
   </Card>
   <Card title="Pricing" icon="tag" href="/pricing">

--- a/start-here/team-setup.mdx
+++ b/start-here/team-setup.mdx
@@ -70,7 +70,7 @@ Once Lindy is installed in your team's Slack, anyone can add themselves just by 
   **Admins stay in the loop.** Every admin gets an email when someone joins this way: who they are, that their first week is free, and a one-click link to remove them. If you remove a seat and that person @mentions Lindy again, it tells them it can't help and pings an admin. It won't quietly re-add them.
 </Note>
 
-For how seats and the shared credit pool work, see [Billing](/coming-soon/lindy-teammate-billing). To get Lindy into Slack in the first place, see [Set up Lindy](/coming-soon/setup).
+For how seats and the shared credit pool work, see [Billing](/teammate/billing). To get Lindy into Slack in the first place, see [Set up Lindy](/teammate/setup).
 
 ## Admin Controls
 

--- a/teammate/billing.mdx
+++ b/teammate/billing.mdx
@@ -67,10 +67,10 @@ A few things depend on your plan:
 ## Relevant Docs
 
 <CardGroup cols={2}>
-  <Card title="Lindy Teammate" icon="slack" href="/coming-soon/lindy-teammate">
+  <Card title="Lindy Teammate" icon="slack" href="/teammate/overview">
     What Lindy does in your team's Slack, per person and per team
   </Card>
-  <Card title="Routines" icon="bolt" href="/coming-soon/routines">
+  <Card title="Routines" icon="bolt" href="/teammate/routines">
     Recurring work Lindy runs on a schedule
   </Card>
 </CardGroup>

--- a/teammate/files.mdx
+++ b/teammate/files.mdx
@@ -57,7 +57,7 @@ A switcher at the top of the explorer flips between your scopes:
 
 Files aren't just storage. They can extend what Lindy can do.
 
-- **Skills** live in a `.skills/` folder. Each skill is a folder with a `SKILL.md` (a name, description, and instructions), and the folder name is the skill name. Lindy sees the names and descriptions of enabled skills, and pulls in a skill's full instructions on demand when it's relevant. Skills layer across scopes: your Personal version overrides the Team's, which overrides the built-in System one. Browse and install ready-made skills from the [Skills](/coming-soon/skills) page and marketplace; installing one copies it into your Personal or Team files.
+- **Skills** live in a `.skills/` folder. Each skill is a folder with a `SKILL.md` (a name, description, and instructions), and the folder name is the skill name. Lindy sees the names and descriptions of enabled skills, and pulls in a skill's full instructions on demand when it's relevant. Skills layer across scopes: your Personal version overrides the Team's, which overrides the built-in System one. Browse and install ready-made skills from the [Skills](/teammate/skills) page and marketplace; installing one copies it into your Personal or Team files.
 - **Memory** lives in a `.memory/` area, where Lindy keeps durable knowledge it can rely on across tasks.
 
 ## Editing and saving
@@ -76,10 +76,10 @@ Files open in a viewer with **Preview**, **Raw**, and **History** tabs. Editable
 ## Relevant Docs
 
 <CardGroup cols={2}>
-  <Card title="Skills" icon="graduation-cap" href="/coming-soon/skills">
+  <Card title="Skills" icon="graduation-cap" href="/teammate/skills">
     Turn files into capabilities Lindy picks up on its own
   </Card>
-  <Card title="Routines" icon="clock-rotate-left" href="/coming-soon/routines">
+  <Card title="Routines" icon="clock-rotate-left" href="/teammate/routines">
     Have Lindy produce files on a schedule
   </Card>
 </CardGroup>

--- a/teammate/home.mdx
+++ b/teammate/home.mdx
@@ -57,16 +57,16 @@ Use the **Customize** menu ("Show on home") to show or hide cards, and dismiss a
 ## Relevant Docs
 
 <CardGroup cols={2}>
-  <Card title="Lindy Teammate" icon="slack" href="/coming-soon/lindy-teammate">
+  <Card title="Lindy Teammate" icon="slack" href="/teammate/overview">
     Give your whole team a shared Lindy in Slack
   </Card>
-  <Card title="Routines" icon="clock-rotate-left" href="/coming-soon/routines">
+  <Card title="Routines" icon="clock-rotate-left" href="/teammate/routines">
     Recurring work Lindy runs on a schedule
   </Card>
-  <Card title="Files" icon="files" href="/coming-soon/files">
+  <Card title="Files" icon="files" href="/teammate/files">
     Browse and manage the files Lindy uses
   </Card>
-  <Card title="Meeting Library" icon="video" href="/coming-soon/meeting-library">
+  <Card title="Meeting Library" icon="video" href="/teammate/meeting-library">
     Group and share your recorded meetings
   </Card>
 </CardGroup>

--- a/teammate/meeting-library.mdx
+++ b/teammate/meeting-library.mdx
@@ -166,10 +166,10 @@ Access means viewing the folder and its meetings and adding or removing meetings
 ## Relevant Docs
 
 <CardGroup cols={2}>
-  <Card title="Files" icon="files" href="/coming-soon/files">
+  <Card title="Files" icon="files" href="/teammate/files">
     The file explorer for everything Lindy uses
   </Card>
-  <Card title="Routines" icon="clock-rotate-left" href="/coming-soon/routines">
+  <Card title="Routines" icon="clock-rotate-left" href="/teammate/routines">
     Recurring work Lindy runs on a schedule
   </Card>
 </CardGroup>

--- a/teammate/overview.mdx
+++ b/teammate/overview.mdx
@@ -112,15 +112,15 @@ Tune how the shared Lindy works from the settings page:
 
 ## Billing
 
-Lindy Teammate is billed per person, as **Teammate Seats**. The first time someone new @mentions Lindy in Slack, they get a free week before their seat converts to paid. See [Billing](/coming-soon/lindy-teammate-billing) for the full picture.
+Lindy Teammate is billed per person, as **Teammate Seats**. The first time someone new @mentions Lindy in Slack, they get a free week before their seat converts to paid. See [Billing](/teammate/billing) for the full picture.
 
 ## Relevant Docs
 
 <CardGroup cols={2}>
-  <Card title="Billing" icon="credit-card" href="/coming-soon/lindy-teammate-billing">
+  <Card title="Billing" icon="credit-card" href="/teammate/billing">
     Seats, trials, and your shared credit pool
   </Card>
-  <Card title="Routines" icon="bolt" href="/coming-soon/routines">
+  <Card title="Routines" icon="bolt" href="/teammate/routines">
     Recurring work Lindy runs on a schedule
   </Card>
 </CardGroup>

--- a/teammate/routines.mdx
+++ b/teammate/routines.mdx
@@ -112,10 +112,10 @@ Tune a routine from the Routines page, or just ask Lindy:
 ## Relevant Docs
 
 <CardGroup cols={2}>
-  <Card title="Skills" icon="graduation-cap" href="/coming-soon/skills">
+  <Card title="Skills" icon="graduation-cap" href="/teammate/skills">
     Reusable playbooks Lindy picks up on its own
   </Card>
-  <Card title="Home" icon="house" href="/coming-soon/home">
+  <Card title="Home" icon="house" href="/teammate/home">
     Where you talk to Lindy and see what it's done
   </Card>
 </CardGroup>

--- a/teammate/setup.mdx
+++ b/teammate/setup.mdx
@@ -86,7 +86,7 @@ Each connected account has one setting: **Always allow** or **Ask for approval**
 ## Relevant Docs
 
 <CardGroup cols={2}>
-  <Card title="Home" icon="house" href="/coming-soon/home">
+  <Card title="Home" icon="house" href="/teammate/home">
     Where you talk to Lindy and see what it's done
   </Card>
   <Card title="Pricing" icon="tag" href="/pricing">

--- a/teammate/skills.mdx
+++ b/teammate/skills.mdx
@@ -120,7 +120,7 @@ Lindy always sees the list of available skills, just their names and description
 ## Relevant Docs
 
 <CardGroup cols={2}>
-  <Card title="Routines" icon="bolt" href="/coming-soon/routines">
+  <Card title="Routines" icon="bolt" href="/teammate/routines">
     Standing instructions that run on a schedule
   </Card>
   <Card title="Ad Hoc Tasks" icon="wand-magic-sparkles" href="/features/ad-hoc-tasks">

--- a/teammate/slack-commands.mdx
+++ b/teammate/slack-commands.mdx
@@ -48,7 +48,7 @@ Anyone can run these for their own account.
 ## Relevant Docs
 
 <CardGroup cols={2}>
-  <Card title="Set up Lindy" icon="slack" href="/coming-soon/setup">
+  <Card title="Set up Lindy" icon="slack" href="/teammate/setup">
     Add Lindy to Slack and link your account
   </Card>
   <Card title="Team Setup" icon="users" href="/start-here/team-setup">


### PR DESCRIPTION
The flagship product's URLs literally read "coming soon" — `/coming-soon/setup`, `/coming-soon/skills`, etc. This moves all 9 Teammate pages to `/teammate/*`.

**Moves**
| old | new |
|---|---|
| `/coming-soon/setup` | `/teammate/setup` |
| `/coming-soon/home` | `/teammate/home` |
| `/coming-soon/meeting-library` | `/teammate/meeting-library` |
| `/coming-soon/files` | `/teammate/files` |
| `/coming-soon/routines` | `/teammate/routines` |
| `/coming-soon/skills` | `/teammate/skills` |
| `/coming-soon/slack-commands` | `/teammate/slack-commands` |
| `/coming-soon/lindy-teammate` | `/teammate/overview` |
| `/coming-soon/lindy-teammate-billing` | `/teammate/billing` |

The last two were renamed to drop the redundant `lindy-teammate` prefix (`/teammate/lindy-teammate-billing` would have read badly).

**Also**
- Permanent redirects added for all 9 old paths, so existing links and search results keep working.
- 40 internal links updated across 10 pages (`index`, `pricing`, `quickstart`, `team-setup`, `usage`, the 4 inbox routine pages, and the Teammate pages themselves).
- Verified every `/teammate/*` link resolves and `docs.json` parses. No content changes.

**Note:** `/teammate/overview` is still orphaned — it's a live 968-word page that isn't in the nav (it wasn't before this PR either). Worth slotting in when the Teammate nav group gets restructured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)