### PR TITLE
docs: correct Secrets location to Settings

### DIFF
--- a/integrations/secrets.mdx
+++ b/integrations/secrets.mdx
@@ -17,7 +17,7 @@ Secrets belong to the **workspace**, not to a person and not to one agent. Save 
 
 <Steps>
   <Step title="Open Secrets">
-    Go to **Integrations**, then **Secrets**.
+    Go to **Settings**, then **Secrets**.
   </Step>
   <Step title="Add a new secret">
     Give it a **name** and paste the **value**. Both are required.


### PR DESCRIPTION
The Secrets page shipped in #309 said "Go to **Integrations**, then **Secrets**". That was inferred from the GraphQL contract, not observed, and it was wrong.

Secrets live under **Settings → Secrets**. Corrected by Alon.

One-line change to the first `<Step>` in `integrations/secrets.mdx`.

## Still unverified

The MCP page's equivalent step still reads "Go to **Integrations**, then **MCP**", which was inferred the same way and has not been confirmed. If MCP is also under Settings, that needs the same fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)